### PR TITLE
Protex component import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - COPILOT_DETECT_OPTIONS="--detect.pip.requirements.path=./requirements.txt"
 # There aren't any tests (yet); just supplying a script to give the build something to do
 script:
-  - python -m unittest
+  - pytest
 
 after_success:
   - bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+
+# If your build needs more advanced behavior, see detailed Travis CI instructions:
+# https://docs.travis-ci.com/user/languages/python/
+
+python:
+  - "3.6"
+
+install:
+  - pip install -r requirements.txt
+
+env:
+  - COPILOT_DETECT_OPTIONS="--detect.pip.requirements.path=./requirements.txt"
+# There aren't any tests (yet); just supplying a script to give the build something to do
+script:
+  - python -m unittest
+
+after_success:
+  - bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ The hub-rest-api-python provides Python bindings for Hub REST API.
 
 Include project directory in your PYTHONPATH or add HubRestAPI.py file directly to your project tree
 
+## Test ##
+Using (pytest)[https://pytest.readthedocs.io/en/latest/contents.html]
+
+```bash
+git clone https://github.com/blackducksoftware/hub-rest-api-python.git
+cd hub-rest-api-python
+# optional but advisable: create/use virtualenv
+# you should have 3.x+, e.g. Python 3.7.0
+
+pip install -r requirements.txt
+export PYTHONPATH=$(pwd)
+pytest
+```
+
 ## Where can I get the latest release? ##
 Clone or download from this page
 

--- a/bds/HubRestApi.py
+++ b/bds/HubRestApi.py
@@ -89,8 +89,16 @@ class HubInstance(object):
         return location
 
     def find_component_info_for_protex_component(self, protex_component_id, protex_component_release_id):
+        '''Will return the Hub component corresponding to the protex_component_id, and if a release (version) id
+        is given, the response will also include the component-version. Returns an empty list if there were
+        no components found.
+        '''
         url = self.config['baseurl'] + "/api/components"
-        with_query = url + "?q=bdsuite:{}%23{}&limit=9999".format(protex_component_id, protex_component_release_id)
+        if protex_component_release_id:
+            query = "?q=bdsuite:{}%23{}&limit=9999".format(protex_component_id, protex_component_release_id)
+        else:
+            query = "?q=bdsuite:{}&limit=9999".format(protex_component_id)
+        with_query = url + query
         logging.debug("Finding the Hub componet for Protex component id {}, release id {} using query/url {}".format(
             protex_component_id, protex_component_release_id, with_query))
         response = self.execute_get(with_query)

--- a/create_policy_for_license_and_not_approved_component.py
+++ b/create_policy_for_license_and_not_approved_component.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+'''
+Created on Oct 14, 2018
+
+@author: gsnyder
+
+Create a policy that prevents use of any rejected component
+
+'''
+from bds.HubRestApi import HubInstance
+import json
+from pprint import pprint
+from sys import argv
+
+hub = HubInstance()
+
+policy_json = json.dumps(
+	{"enabled":"true",
+	"overridable":"true",
+	"name":"cannot-use-reciprocal-with-un-approved-component",
+	"description":"Reject use of a component that is governed by a reciprocal license and the approval status is not Approved",
+	"severity":"BLOCKER",
+	"policyType":"BOM_COMPONENT_DISALLOW",
+	"expression":
+		{"operator":"AND",
+		"expressions":[
+				{"name":"LICENSE_FAMILY",
+				"operation":"EQ",
+				"parameters":{
+					"values":[
+						"RECIPROCAL"
+						]
+					}
+				},
+				{"name":"COMPONENT_APPROVAL_STATUS",
+				"operation":"NE",
+				"parameters":{
+					"values":[
+						"APPROVED"
+						]
+					}
+				}
+			]
+		}
+	})
+
+policy_url = hub.create_policy(policy_json)
+print("Policy created is located at: {}".format(policy_url))

--- a/create_policy_for_rejected_components.py
+++ b/create_policy_for_rejected_components.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+'''
+Created on Oct 14, 2018
+
+@author: gsnyder
+
+Create a policy that prevents use of any rejected component
+
+'''
+from bds.HubRestApi import HubInstance
+import json
+from pprint import pprint
+from sys import argv
+
+hub = HubInstance()
+
+policy_json = json.dumps(
+	{"enabled":"true",
+	"overridable": "true",
+	"name":"cannot-use-rejected-component",
+	"description":"You cannot use components we have rejected.",
+	"severity":"BLOCKER",
+	"policyType":"BOM_COMPONENT_DISALLOW",
+	"expression":{
+		"operator":"AND","expressions":[
+			{"name":"COMPONENT_APPROVAL_STATUS","operation":"EQ","parameters":{"values":["REJECTED"]}}
+			]
+		}
+	})
+
+policy_url = hub.create_policy(policy_json)
+print("Policy created is located at: {}".format(policy_url))

--- a/find_hub_component_using_protex_id.py
+++ b/find_hub_component_using_protex_id.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+'''
+Created on Oct 14, 2018
+
+@author: gsnyder
+
+Finds and prints a Hub component given the Protex (or CC) component id and release (version) id
+Note: If no release id is provided, the search will result in a (parent) Hub component (no specific version)
+
+'''
+from bds.HubRestApi import HubInstance
+from pprint import pprint
+from sys import argv
+
+hub = HubInstance()
+
+if __name__ == "__main__":
+	import argparse
+
+	parser = argparse.ArgumentParser()
+	parser.add_argument("protex_component_id", help="The protex component id")
+	parser.add_argument("--release", default=None, help="The protex component release (aka version)")
+	args = parser.parse_args()
+
+	hub_component_info = hub.find_component_info_for_protex_component(args.protex_component_id, args.release)
+
+	pprint(hub_component_info)

--- a/generate_config.py
+++ b/generate_config.py
@@ -5,4 +5,4 @@ Created on Jul 18, 2018
 '''
 from bds.HubRestApi import HubInstance
 
-hub = HubInstance("https://ec2-18-208-209-223.compute-1.amazonaws.com","sysadmin","genesys", insecure=True, debug=True)
+hub = HubInstance("https://ec2-18-217-189-8.us-east-2.compute.amazonaws.com","sysadmin","blackduck", insecure=True, debug=True)

--- a/suite_component_import.py
+++ b/suite_component_import.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+
+import csv
+import logging
+from pprint import pprint
+
+from bds.HubRestApi import HubInstance
+
+
+class SuiteComponentImport(object):
+	# Map from Protex approval status to Hub approval status
+	# TODO: Finish mapping all the code center/protex components approval status values into Hub here
+	APPROVAL_STATUS_MAP = {
+		'NOT_REVIEWED': 'UNREVIEWED',
+		'APPROVED': 'APPROVED',
+		'PENDING': 'UNREVIEWED',
+		'REJECTED': 'REJECTED',
+
+	}
+	COMPONENT_COL_NAME='name'
+	COMPONENT_TYPE_COL_NAME='ComponentType'
+	VERSION_COL_NAME='version'
+	LICENSE_COL_NAME='kblicensename'
+	LICENSE_ID_COL_NAME='kblicenseid'
+	APPROVAL_COL_NAME='status'
+	COMPONENT_ID_COL_NAME='kbcomponentid'
+	RELEASE_ID_COL_NAME='kbreleaseid'
+
+	SUPPORTED_COMPONENT_TYPES = ["STANDARD", "STANDARD_MODIFIED"]
+
+	def __init__(self, suite_component_list_file, hub_instance):
+		'''Expects a pipe-delimited ("|") file with a header row that includes the following fields (note the case and spaces in the names)
+			- Component
+			- Version
+			- License
+			- Approval Status
+			- component id
+			- release id
+		'''
+		self.suite_component_list_file = suite_component_list_file
+		self.hub_instance = hub_instance
+
+	def _import_component_approval_status(self, protex_component_id, protex_approval_status, protex_release_id=None):
+		imported_component_successfully = False
+		protex_release_id = None if protex_release_id == "null" else protex_release_id
+		logging.debug("Searching for Protex component with ID {} and version ID {}".format(protex_component_id, protex_release_id))
+		try:
+			hub_component_info = self.hub_instance.find_component_info_for_protex_component(
+					protex_component_id,
+					protex_release_id
+				)
+			if hub_component_info:
+				if 'version' in hub_component_info:
+					details_url = hub_component_info['version']
+				elif 'component' in hub_component_info:
+					details_url = hub_component_info['component']
+				else:
+					logging.error("Hub component info ({}) did not contain either a component or version url".format(hub_component_info))
+					return False
+
+				component_or_version_details = self.hub_instance.get_component_by_url(details_url)
+
+				if component_or_version_details and 'approvalStatus' in component_or_version_details:
+					logging.debug("Hub component or component version before update: {}".format(component_or_version_details))
+					component_or_version_details['approvalStatus'] = SuiteComponentImport.APPROVAL_STATUS_MAP[
+						protex_approval_status]
+
+					self.hub_instance.update_component_by_url(details_url, component_or_version_details)
+					imported_component_successfully = True
+					
+					component_or_version_details = self.hub_instance.get_component_by_url(details_url)
+					logging.debug("Hub component or component version after update: {}".format(component_or_version_details))
+			else:
+				logging.warning('Could not locate Hub component or component version for Protex component id {} and release id {}'.format(protex_component_id, protex_release_id))
+		except:
+			logging.error(
+				"Ooops. Something went very wrong for Protex component {}, release {}".format(protex_component_id, protex_release_id),
+				exc_info=True)
+			imported_component_successfully = False
+		finally:
+			return imported_component_successfully
+
+	def _dump_updated_to_file(self, failed):
+		self._dump_to_file(failed, "-updated.csv")
+
+	def _dump_failed_to_file(self, failed):
+		self._dump_to_file(failed, "-failed.csv")
+
+	def _dump_skipped_to_file(self, skipped):
+		self._dump_to_file(skipped, "-skipped.csv")
+		
+	def _dump_to_file(self, component_list, extension):
+		# import pdb; pdb.set_trace()
+		dump_csv_file = self.suite_component_list_file.replace(".csv", extension)
+		with open(dump_csv_file, 'w', newline='') as csvfile:
+			fieldnames = [
+				SuiteComponentImport.COMPONENT_COL_NAME,
+				SuiteComponentImport.VERSION_COL_NAME,
+				SuiteComponentImport.LICENSE_COL_NAME,
+				SuiteComponentImport.LICENSE_ID_COL_NAME,
+				SuiteComponentImport.APPROVAL_COL_NAME,
+				SuiteComponentImport.COMPONENT_ID_COL_NAME,
+				SuiteComponentImport.RELEASE_ID_COL_NAME
+			]
+			writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+			writer.writeheader()
+			for component in component_list:
+				writer.writerow(component)
+		logging.info("Dumped {} components into {}".format(len(component_list), dump_csv_file))
+
+	def _import_component(self, suite_component_info):
+		try:
+			component_id = suite_component_info[SuiteComponentImport.COMPONENT_ID_COL_NAME]
+			version_id = suite_component_info[SuiteComponentImport.RELEASE_ID_COL_NAME]
+			approval_status = suite_component_info[SuiteComponentImport.APPROVAL_COL_NAME]
+		except KeyError:
+			logging.error("Missing required key in component info ({}), skipping...".format(suite_component_info))
+			return False
+		return self._import_component_approval_status(component_id,	approval_status, version_id)
+
+	def import_components(self):
+		with open(args.suite_component_list, newline='') as component_list_file:
+			reader = csv.DictReader(component_list_file, delimiter="|")
+			updated = []
+			failed = []
+			skipped = []
+			for suite_component_info in reader:
+				# if component type not give, default to STANDARD (i.e. KB component)
+				component_type = suite_component_info.get(SuiteComponentImport.COMPONENT_TYPE_COL_NAME, "STANDARD")
+				if component_type in SuiteComponentImport.SUPPORTED_COMPONENT_TYPES:
+					logging.debug("Importing suite component: {}".format(suite_component_info))
+					if self._import_component(suite_component_info):
+						logging.info("Updated the Hub with suite component: {}".format(suite_component_info))
+						updated.append(suite_component_info)
+					else:
+						logging.warn("Failed to update suite component: {}".format(suite_component_info))
+						failed.append(suite_component_info)
+				else:
+					logging.debug("Skipping suite component because the type ({}) is not in supported types ({})".format(
+						component_type, SuiteComponentImport.SUPPORTED_COMPONENT_TYPES))
+					skipped.append(suite_component_info)
+
+			logging.info("Updated {} suite components or component versions".format(len(updated)))
+			self._dump_updated_to_file(updated)
+
+			if len(failed) > 0:
+				logging.info("Failed to update {} suite components or component versions".format(len(failed)))
+				self._dump_failed_to_file(failed)
+			if len(skipped) > 0:
+				logging.info(
+					"Skipped {} suite components or component versions because their type was not in {} types".format(
+						len(skipped), SuiteComponentImport.SUPPORTED_COMPONENT_TYPES)
+					)
+				self._dump_skipped_to_file(skipped)
+
+if __name__ == "__main__":
+	import argparse
+	import sys
+
+	parser = argparse.ArgumentParser()
+	parser.add_argument("suite_component_list", help="Pipe-delimited file containing the component information from Protex")
+	parser.add_argument("--loglevel", choices=["CRITICAL", "DEBUG", "ERROR", "INFO", "WARNING"], default="DEBUG", help="Choose the desired logging level - CRITICAL, DEBUG, ERROR, INFO, or WARNING. (default: DEBUG)")
+	args = parser.parse_args()
+
+	logging_levels = {
+		'CRITICAL': logging.CRITICAL,
+		'DEBUG': logging.DEBUG,
+		'ERROR': logging.ERROR,
+		'INFO': logging.INFO,
+		'WARNING': logging.WARNING,
+	}
+	logging.basicConfig(stream=sys.stdout, format='%(threadName)s: %(asctime)s: %(levelname)s: %(message)s', level=logging_levels[args.loglevel])
+
+	hub = HubInstance()
+
+	protex_importer = SuiteComponentImport(args.suite_component_list, hub)
+
+	protex_importer.import_components()
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/test_hub_rest_api_python.py
+++ b/test/test_hub_rest_api_python.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+ 
+import pytest
+from bds.HubRestApi import HubInstance
+
+class TestHubInstance(object):
+	def setUp(self):
+		pass
+
+	def test_hub_instance_writes_config_when_instantiated(self):
+		pass
+		
+	def test_hub_instance_username_password_for_auth(self):
+		pass
+
+	def test_hub_instance_api_token_for_auth(self):
+		pass
+
+	def test_hub_instance_api_token_for_auth_takes_precedence(self):
+		pass
+
+	def test_hub_instance_can_ignore_invalid_ssl_with_insecure_set(self):
+		pass
+
+	def tearDown(self):
+		pass

--- a/test/test_suite_component_import.py
+++ b/test/test_suite_component_import.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+ 
+import pytest
+from suite_component_import import SuiteComponentImport
+from unittest import mock
+
+
+def test_import_component_returns_false_if_one_or_more_keys_missing():
+	sci = SuiteComponentImport("my-component-list", hub_instance = mock.Mock())
+	sci._import_component_approval_status = mock.Mock()
+
+	component_info = {
+		SuiteComponentImport.COMPONENT_ID_COL_NAME : "fake-component-id",
+		SuiteComponentImport.RELEASE_ID_COL_NAME : 'fake-release-id',
+	}
+
+	assert sci._import_component(component_info) == False
+	assert sci._import_component_approval_status.called == False
+
+def test_import_component_with_all_values_present():
+	sci = SuiteComponentImport("my-component-list", hub_instance = mock.Mock())
+	sci._import_component_approval_status = mock.MagicMock()
+	sci._import_component_approval_status.return_value = True
+
+	component_info = {
+		SuiteComponentImport.COMPONENT_ID_COL_NAME : "fake-component-id",
+		SuiteComponentImport.RELEASE_ID_COL_NAME : 'fake-release-id',
+		SuiteComponentImport.APPROVAL_COL_NAME : 'APPROVED'
+	}
+
+	assert sci._import_component(component_info) == True
+	sci._import_component_approval_status.assert_called_once_with('fake-component-id', 'APPROVED', 'fake-release-id')
+
+

--- a/update_component_approval_status.py
+++ b/update_component_approval_status.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+'''
+Created on Oct 14, 2018
+
+@author: gsnyder
+
+Updates the approval status for a component given it's component ID
+
+'''
+from bds.HubRestApi import HubInstance
+from pprint import pprint
+from sys import argv
+
+hub = HubInstance()
+
+component_id = argv[1]
+component_info = hub.get_component_by_id(component_id)
+
+if "approvalStatus" in component_info:
+	print("Component data before update:")
+	pprint(component_info)
+	update_body = component_info
+	update_body["approvalStatus"] = "APPROVED"
+	try:
+		hub.update_component_by_id(component_id, update_body)
+	except:
+		print("Failed to update approval status for component ({})".format(component_id))
+	print("\n\nComponent data after update:")
+	pprint(hub.get_component_by_id(component_id))


### PR DESCRIPTION
Extending HubRestApi to include support for 
1. finding Hub components given the suite (either Protex or CC) component id, and release (version) id
1. get'ing Hub component info by ID or by URL
1. post'ing (create) new objects
1. put'ing (modify) objects

Also adding:
1. suite_component_import.py to support taking a pipe-dilim export of KB components from Protex or CC and importing their approval status into the Hub
1. create_policy_for_license_and_not_approved_component.py
1. create_policy_for_rejected_components.py 
1. find_hub_component_using_protex_id.py
1. update_component_approval_status.py

Hopefully the names are self-explanatory.

Also adding "test" directory with some scaffolding to support running pytest unit tests.