### PR TITLE
fix restconfig debug & boolean handling

### DIFF
--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -76,7 +76,7 @@ class HubInstance(object):
                 self.config['username'] = args[1]
                 self.config['password'] = args[2]
             self.config['insecure'] = kwargs.get('insecure', False)
-            self.config['debug'] = kwargs.get('insecure', False)
+            self.config['debug'] = kwargs.get('debug', False)
 
             if kwargs.get('write_config_flag', True):
                 self.write_config()

--- a/restconfig.json.example
+++ b/restconfig.json.example
@@ -4,7 +4,7 @@
  "username": "",
  "password": "",
  "baseurl": "https://127.0.0.1",
- "insecure": "True",
- "debug": "True"
+ "insecure": true,
+ "debug": true
 
 }


### PR DESCRIPTION
The example restconfig is misleading because it has the JSON string
"True" instead of the boolean value true (without quotes).  When
someone tries setting it to "False" it won't work because that's a
valid JSON string that python evaluates to true in places that say
"if config['debug'] ..."

Also fix a typo where the debug value is initialized from the
'insecure' keyword argument.