### PR TITLE
adding support for v3.7.x REST API authentication

### DIFF
--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,4 +1,4 @@
 
-VERSION = (0, 0, 4)
+VERSION = (0, 0, 5)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
Modifying the authentication and header management to accommodate working with v3.7.x of Hub, while preserving compatibility with newer versions.