### PR TITLE
adding support for user and user groups and role assignments

### DIFF
--- a/examples/dump_policies.py
+++ b/examples/dump_policies.py
@@ -1,0 +1,73 @@
+'''
+Created on Dec 5, 2018
+
+@author: gsnyder
+
+Dump policies to a file
+
+'''
+import argparse
+import json
+import logging
+from pprint import pprint
+import sys
+
+from blackduck.HubRestApi import HubInstance, CreateFailedAlreadyExists
+
+
+def serialize_to_file(file, data):
+	with open(file, "w") as f:
+		json.dump(data, f, indent=3)
+
+parser = argparse.ArgumentParser("Dump policies from a Hub instance")
+parser.add_argument("base_filename", help="There will be two files dumped - one raw and one prepped to copy policies to another Hub instance")
+args = parser.parse_args()
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+source_hub = HubInstance()
+
+policy_keys_to_delete = [
+	'_meta', 
+	'href', 
+	'links', 
+	'createdAt', 
+	'createdBy',
+	'createdByUser',
+	'updatedAt', 
+	'updatedBy',
+	'updatedByUser']
+
+policies_to_copy = source_hub.get_policies()
+
+if 'totalCount' in policies_to_copy and policies_to_copy['totalCount'] > 0:
+	logging.debug("Dumping {} policies from {}".format(policies_to_copy['totalCount'], source_hub.config['baseurl']))
+	assert 'items' in policies_to_copy, "Should always be a list of items in a non-zero list of policies"
+
+	policy_data_raw = []
+	policy_data_prepped_to_copy = []
+
+	for policy in policies_to_copy['items']:
+		import pdb; pdb.set_trace()
+		policy = source_hub.get_policy_by_url(policy['_meta']['href'])
+		policy_data_raw.append(policy)
+
+		policy_copy_prepped_to_create = policy.copy()
+
+		for k in policy_keys_to_delete:
+			if k in policy_copy_prepped_to_create:
+				del policy_copy_prepped_to_create[k]
+
+		policy_data_prepped_to_copy.append(policy_copy_prepped_to_create)
+
+	raw_file = args.base_filename + ".raw"
+	prepped_file = args.base_filename + ".prepped"
+
+	serialize_to_file(raw_file, policy_data_raw)
+	serialize_to_file(prepped_file, policy_data_prepped_to_copy)
+else:
+	logging.info("No policies to dump")
+
+
+
+		

--- a/examples/dump_user_groups.py
+++ b/examples/dump_user_groups.py
@@ -1,0 +1,73 @@
+'''
+Created on Dec 5, 2018
+
+@author: gsnyder
+
+Dump user groups to a file
+
+'''
+import argparse
+import json
+import logging
+from pprint import pprint
+import sys
+
+from blackduck.HubRestApi import HubInstance, CreateFailedAlreadyExists
+
+
+def serialize_to_file(file, data):
+	with open(file, "w") as f:
+		json.dump(data, f, indent=3)
+
+parser = argparse.ArgumentParser("Dump user_groups from a Hub instance")
+parser.add_argument("base_filename", help="There will be two files dumped - one raw and one prepped to copy user_groups to another Hub instance")
+args = parser.parse_args()
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+source_hub = HubInstance()
+
+user_group_keys_to_delete = ['_meta', 'href', 'links']
+
+user_groups_to_copy = source_hub.get_user_groups()
+
+if 'totalCount' in user_groups_to_copy and user_groups_to_copy['totalCount'] > 0:
+	logging.debug("Dumping {} user_groups from {}".format(user_groups_to_copy['totalCount'], source_hub.config['baseurl']))
+	assert 'items' in user_groups_to_copy, "Should always be a list of items in a non-zero list of user_groups"
+
+	user_group_data_raw = []
+	user_group_data_prepped_to_copy = []
+
+	for user_group in user_groups_to_copy['items']:
+		user_group_roles_response = source_hub.get_roles_for_user_or_group(user_group)
+		if user_group_roles_response:
+			user_group_roles = user_group_roles_response.json()
+		else:
+			user_group_roles = []
+
+		user_group_data_raw.append({
+			'user_group': user_group, 'roles': user_group_roles
+			})
+
+		user_group_copy_prepped_to_create = user_group.copy()
+		for k in user_group_keys_to_delete:
+			if k in user_group_copy_prepped_to_create:
+				del user_group_copy_prepped_to_create[k]
+
+		user_group_roles_to_create = [role['name'] for role in user_group_roles['items']]
+
+		user_group_data_prepped_to_copy.append({
+			'user_group': user_group_copy_prepped_to_create, 'roles': user_group_roles_to_create
+			})
+
+	raw_file = args.base_filename + ".raw"
+	prepped_file = args.base_filename + ".prepped"
+
+	serialize_to_file(raw_file, user_group_data_raw)
+	serialize_to_file(prepped_file, user_group_data_prepped_to_copy)
+else:
+	logging.info("No user groups to dump")
+
+
+
+		

--- a/examples/dump_users.py
+++ b/examples/dump_users.py
@@ -1,0 +1,80 @@
+'''
+Created on Dec 4, 2018
+
+@author: gsnyder
+
+Copy users and their roles from one Hub instance to another
+
+'''
+import argparse
+import json
+import logging
+from pprint import pprint
+import sys
+
+from blackduck.HubRestApi import HubInstance, CreateFailedAlreadyExists
+
+
+def serialize_to_file(file, data):
+	with open(file, "w") as f:
+		json.dump(data, f, indent=3)
+
+parser = argparse.ArgumentParser("Dump users from a Hub instance")
+parser.add_argument("base_filename", help="There will be two files dumped - one raw and one prepped to copy users to another Hub instance")
+args = parser.parse_args()
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+source_hub = HubInstance()
+
+user_keys_to_delete = ['_meta', 'href', 'links']
+
+users_to_copy = source_hub.get_users()
+
+if 'totalCount' in users_to_copy and users_to_copy['totalCount'] > 0:
+	logging.info("Dumping {} users from {}".format(users_to_copy['totalCount'], source_hub.config['baseurl']))
+	assert 'items' in users_to_copy, "Should always be a list of items in a non-zero list of users"
+
+	user_data_raw = []
+	user_data_prepped_to_copy = []
+
+	for user in users_to_copy['items']:
+		if user['userName'] == 'sysadmin':
+			continue
+		# pprint(user)
+		user_roles_response = source_hub.get_roles_for_user_or_group(user)
+		if user_roles_response:
+			user_roles = user_roles_response.json()
+		else:
+			user_roles = []
+
+		user_data_raw.append({
+			'user': user, 'roles': user_roles
+			})
+
+		user_copy_prepped_to_create = user.copy()
+		for k in user_keys_to_delete:
+			if k in user_copy_prepped_to_create:
+				del user_copy_prepped_to_create[k]
+
+		# Need to add a password value to get Hub to create the user even
+		# for EXTERNAL users
+		if 'password' not in user_copy_prepped_to_create:
+			user_copy_prepped_to_create['password'] = 'blackduck'
+
+		user_roles_to_create = [role['name'] for role in user_roles['items']]
+
+		user_data_prepped_to_copy.append({
+			'user': user_copy_prepped_to_create, 'roles': user_roles_to_create
+			})
+
+	raw_file = args.base_filename + ".raw"
+	prepped_file = args.base_filename + ".prepped"
+
+	serialize_to_file(raw_file, user_data_raw)
+	serialize_to_file(prepped_file, user_data_prepped_to_copy)
+else:
+	logging.info("No users to dump")
+
+
+		

--- a/examples/get_user_groups.py
+++ b/examples/get_user_groups.py
@@ -1,0 +1,20 @@
+'''
+Created on Dec 4, 2018
+
+@author: gsnyder
+
+Get a list of user objects
+
+'''
+import json
+
+from blackduck.HubRestApi import HubInstance
+
+hub = HubInstance()
+
+user_groups = hub.get_user_groups()
+
+if 'totalCount' in user_groups and user_groups['totalCount'] > 0:
+	print(json.dumps(user_groups))
+else:
+	print("No user_groups found")

--- a/examples/get_users.py
+++ b/examples/get_users.py
@@ -1,0 +1,20 @@
+'''
+Created on Dec 4, 2018
+
+@author: gsnyder
+
+Get a list of user objects
+
+'''
+import json
+
+from blackduck.HubRestApi import HubInstance
+
+hub = HubInstance()
+
+users = hub.get_users()
+
+if 'totalCount' in users and users['totalCount'] > 0:
+	print(json.dumps(users))
+else:
+	print("No users found")

--- a/examples/upload_policies.py
+++ b/examples/upload_policies.py
@@ -41,7 +41,6 @@ if not policies_to_copy:
 for policy_info in policies_to_copy:
 	new_policy_result = {}
 	try:
-		import pdb; pdb.set_trace()
 		new_policy_result = dest_hub.create_policy(policy_info)
 	except CreateFailedAlreadyExists:
 		logging.warning("policy with name {} already exists".format(policy_info['name']))
@@ -49,11 +48,7 @@ for policy_info in policies_to_copy:
 		logging.error("Unknown error occurred while attempting to add policy {}".format(
 			policy_info['name']), exc_info=True)
 	else:
-		if new_policy_result.status_code == 201:
-			logging.info("Created new policy, details {}".format(new_policy_result))
-		else:
-			logging.error("Failed to add policy {}, details {}".format(
-				policy_info['name'], new_policy_result.json()))
+		logging.info("Created new policy, details {}".format(new_policy_result))
 
 
 

--- a/examples/upload_policies.py
+++ b/examples/upload_policies.py
@@ -1,0 +1,63 @@
+'''
+Created on Dec 5, 2018
+
+@author: gsnyder
+
+Upload policies from a file to a Black Duck server
+
+'''
+import argparse
+import json
+import logging
+from pprint import pprint
+import sys
+
+from blackduck.HubRestApi import HubInstance, CreateFailedAlreadyExists
+
+
+parser = argparse.ArgumentParser("Upload policies to a Hub instance from a file")
+parser.add_argument("policies_file", help="A json-formatter file containing all the policies")
+parser.add_argument("dest_url", help="The URL for the destination Hub instance")
+parser.add_argument("dest_username", default="sysadmin", help="The destination user account - default: sysadmin")
+parser.add_argument("dest_password", default="blackduck")
+
+args = parser.parse_args()
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+dest_hub = HubInstance(
+	args.dest_url, 
+	args.dest_username,
+	args.dest_password,
+	write_config_flag=False,
+	insecure=True)
+
+f =  open(args.policies_file, 'r')
+policies_to_copy = json.load(f)
+
+if not policies_to_copy:
+	logging.debug("No policies to copy, sure you used the right file?")
+	
+for policy_info in policies_to_copy:
+	new_policy_result = {}
+	try:
+		import pdb; pdb.set_trace()
+		new_policy_result = dest_hub.create_policy(policy_info)
+	except CreateFailedAlreadyExists:
+		logging.warning("policy with name {} already exists".format(policy_info['name']))
+	except:
+		logging.error("Unknown error occurred while attempting to add policy {}".format(
+			policy_info['name']), exc_info=True)
+	else:
+		if new_policy_result.status_code == 201:
+			logging.info("Created new policy, details {}".format(new_policy_result))
+		else:
+			logging.error("Failed to add policy {}, details {}".format(
+				policy_info['name'], new_policy_result.json()))
+
+
+
+
+
+
+		

--- a/examples/upload_user_groups.py
+++ b/examples/upload_user_groups.py
@@ -1,0 +1,99 @@
+'''
+Created on Dec 4, 2018
+
+@author: gsnyder
+
+Upload user groups from a file to a Black Duck server
+
+'''
+import argparse
+import json
+import logging
+from pprint import pprint
+import sys
+
+from blackduck.HubRestApi import HubInstance, CreateFailedAlreadyExists
+
+
+parser = argparse.ArgumentParser("Upload user_groups to a Hub instance from a file")
+parser.add_argument("user_groups_file", help="A json-formatter file containing all the user_group data, including their roles")
+parser.add_argument("dest_url", help="The URL for the destination Hub instance")
+parser.add_argument("dest_username", default="sysadmin", help="The destination user account - default: sysadmin")
+parser.add_argument("dest_password", default="blackduck")
+
+args = parser.parse_args()
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+dest_hub = HubInstance(
+	args.dest_url, 
+	args.dest_username,
+	args.dest_password,
+	write_config_flag=False,
+	insecure=True)
+
+f =  open(args.user_groups_file, 'r')
+user_groups_to_copy = json.load(f)
+
+if not user_groups_to_copy:
+	logging.debug("No user_groups to copy, sure you used the right file?")
+	
+def get_user_group(dest_hub, user_group_copy):
+	# filtering did not appear to work so doing it on the app side
+	user_groups = dest_hub.get_user_groups()
+	if 'totalCount' in user_groups and user_groups['totalCount'] > 0:
+		assert 'items' in user_groups, "Should always be an items list when totalCount > 0"
+
+		for user_group in user_groups['items']:
+			if user_group['name'] == user_group_copy['name']:
+				return user_group
+	return None
+
+for user_group_info in user_groups_to_copy:
+	assert 'user_group' in user_group_info, "There must be a user_group object in each record"
+	assert 'roles' in user_group_info, "There must be a list of role names in each record"
+
+	user_group_copy = user_group_info['user_group']
+	role_names = user_group_info['roles']
+
+	new_user_group_result = {}
+	try:
+		new_user_group_result = dest_hub.create_user_group(user_group_copy)
+	except CreateFailedAlreadyExists:
+		logging.warning("user_group with name {} already exists".format(user_group_copy['name']))
+	except:
+		logging.error("Unknown error occurred while attempting to add user_group {}".format(
+			user_group_copy['name']), exc_info=True)
+	else:
+		logging.info("Created new user_group, details {}".format(new_user_group_result))
+
+	# We need a copy of the newly (or recently) created user group
+	new_user_group = get_user_group(dest_hub, user_group_copy)
+
+	if not role_names:
+		logging.debug("No roles to assign to user_group {}".format(user_group_copy['name']))
+	else:
+		logging.debug('Assigning user_group roles {} to new user_group {} on hub at {}'.format(
+			role_names, user_group_copy['name'], dest_hub.get_urlbase()))
+
+	for role in role_names:
+		try:
+			add_role_response = dest_hub.assign_role_to_user_or_group(role, new_user_group)
+		except:
+			logging.error("Failed to assign role {} to user_group {}".format(
+				role, user_group_copy['name']), exc_info=True)
+		else:
+			if add_role_response.status_code == 201:
+				logging.info("Added role {} to user_group {}".format(role, user_group_copy['name']))
+			else:
+				logging.error("Failed to add role {} to user_group {}, details {}".format(
+					role, user_group_copy['name'], add_role_response.json()))
+	# TODO: v3 returns different info than v4+ so need to work out what to do here
+	# new_user_info = dest_hub.get_user_by_url(new_user_url)
+	# logging.debug("New user data: {}".format(new_user_info))
+
+
+
+
+
+		

--- a/examples/upload_users.py
+++ b/examples/upload_users.py
@@ -1,0 +1,98 @@
+'''
+Created on Dec 4, 2018
+
+@author: gsnyder
+
+Upload users from a file to a Black Duck server
+
+'''
+import argparse
+import json
+import logging
+from pprint import pprint
+import sys
+
+from blackduck.HubRestApi import HubInstance, CreateFailedAlreadyExists
+
+
+parser = argparse.ArgumentParser("Upload users to a Hub instance from a file")
+parser.add_argument("users_file", help="A json-formatter file containing all the user data, including their roles")
+parser.add_argument("dest_url", help="The URL for the destination Hub instance")
+parser.add_argument("dest_username", default="sysadmin", help="The destination user account - default: sysadmin")
+parser.add_argument("dest_password", default="blackduck")
+
+args = parser.parse_args()
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+dest_hub = HubInstance(
+	args.dest_url, 
+	args.dest_username,
+	args.dest_password,
+	write_config_flag=False,
+	insecure=True)
+
+f =  open(args.users_file, 'r')
+users_to_copy = json.load(f)
+
+if not users_to_copy:
+	logging.debug("No users to copy, sure you used the right file?")
+	
+def get_user(dest_hub, user_copy):
+	parameters = {'q':'userName:{}'.format(user_copy['userName'])}
+	users = dest_hub.get_users(parameters=parameters)
+	if 'totalCount' in users and users['totalCount'] > 0:
+		assert 'items' in users, "Should always be an items list when totalCount > 0"
+
+		for user in users['items']:
+			if user['userName'] == user_copy['userName']:
+				return user
+	return None
+
+for user_info in users_to_copy:
+	assert 'user' in user_info, "There must be a user object in each record"
+	assert 'roles' in user_info, "There must be a list of role names in each record"
+
+	user_copy = user_info['user']
+	role_names = user_info['roles']
+
+	new_user_url = None
+	try:
+		new_user_url = dest_hub.create_user(user_copy)
+	except CreateFailedAlreadyExists:
+		logging.warning("user with userName {} already exists".format(user_copy['userName']))
+	except:
+		logging.error("Unknown error occurred while attempting to add user {}".format(
+			user_copy['userName']), exc_info=True)
+	else:
+		logging.info("Created new user at location {}".format(new_user_url))
+
+
+	if new_user_url:
+		new_user = dest_hub.get_user_by_url(new_user_url)
+	else:
+		new_user = get_user(dest_hub, user_copy)
+
+	if not role_names:
+		logging.debug("No roles to assign to user {}".format(user_copy['userName']))
+	else:
+		logging.debug('Assigning user roles {} to new user {} on hub at {}'.format(
+			role_names, new_user['userName'], dest_hub.get_urlbase()))
+
+	for role in role_names:
+		try:
+			dest_hub.assign_role_to_user_or_group(role, new_user)
+		except:
+			logging.error("Failed to assign role {} to user {}".format(
+				role, new_user['userName']), exc_info=True)
+		else:
+			logging.info("Added role {} to user {}".format(role, new_user['userName']))
+	# TODO: v3 returns different info than v4+ so need to work out what to do here
+	# new_user_info = dest_hub.get_user_by_url(new_user_url)
+	# logging.debug("New user data: {}".format(new_user_info))
+
+
+
+
+
+		

--- a/test/test_hub_rest_api_python.py
+++ b/test/test_hub_rest_api_python.py
@@ -266,6 +266,7 @@ def test_update_policy_by_url(requests_mock, mock_hub_instance, a_test_policy, a
 def test_create_policy(requests_mock, mock_hub_instance, a_test_policy, a_test_policy_for_create_or_update):
     requests_mock.post(fake_hub_host + "/api/policy-rules", headers={"location": a_test_policy['_meta']['href']}, status_code=201)
     # print(json.dumps(a_test_policy_for_create_or_update))
+    import pdb; pdb.set_trace()
     new_policy_url = mock_hub_instance.create_policy(a_test_policy_for_create_or_update)
     assert new_policy_url == a_test_policy['_meta']['href']
 

--- a/test/test_hub_rest_api_python.py
+++ b/test/test_hub_rest_api_python.py
@@ -96,10 +96,11 @@ def a_test_policy(requests_mock):
 
 @pytest.fixture()
 def a_test_policy_for_create_or_update(requests_mock):
-        a_policy_for_creating_or_updating = dict(
-            (attr, test_policy[attr]) for attr in 
-            ['name', 'description', 'enabled', 'overridable', 'expression', 'severity'] if attr in test_policy)
-        yield a_policy_for_creating_or_updating
+        # a_policy_for_creating_or_updating = dict(
+        #     (attr, test_policy[attr]) for attr in 
+        #     ['name', 'description', 'enabled', 'overridable', 'expression', 'severity'] if attr in test_policy)
+        # yield a_policy_for_creating_or_updating
+        yield test_policy
 
 @pytest.fixture()
 def test_vulnerability_info(requests_mock):
@@ -264,6 +265,7 @@ def test_update_policy_by_url(requests_mock, mock_hub_instance, a_test_policy, a
 
 def test_create_policy(requests_mock, mock_hub_instance, a_test_policy, a_test_policy_for_create_or_update):
     requests_mock.post(fake_hub_host + "/api/policy-rules", headers={"location": a_test_policy['_meta']['href']}, status_code=201)
+    # print(json.dumps(a_test_policy_for_create_or_update))
     new_policy_url = mock_hub_instance.create_policy(a_test_policy_for_create_or_update)
     assert new_policy_url == a_test_policy['_meta']['href']
 
@@ -340,6 +342,30 @@ def test_delete_project_version_by_name():
     pass
 
 
+def test_get_users(requests_mock, mock_hub_instance):
+    pass
+
+def test_create_user(requests_mock, mock_hub_instance):
+    pass
+
+def test_get_user_by_id(requests_mock, mock_hub_instance):
+    pass
+
+def test_get_user_by_url(requests_mock, mock_hub_instance):
+    pass
+
+def test_update_user_by_id(requests_mock, mock_hub_instance):
+    pass
+
+def test_update_user_by_url(requests_mock, mock_hub_instance):
+    pass
+
+def test_delete_user_by_id(requests_mock, mock_hub_instance):
+    pass
+
+def test_delete_user_by_url(requests_mock, mock_hub_instance):
+    pass
+    
 
 
 


### PR DESCRIPTION
Extending the API bindings to include support for user, user groups, and role assignments so we can copy users, user groups, and their roles and subsequently use those copies to create new ones in a different server for instance.
