### PR TITLE
adding sample code showing how to find project-versions that have a word in the Notes field

### DIFF
--- a/examples/get_project_versions_by_word_in_notes.py
+++ b/examples/get_project_versions_by_word_in_notes.py
@@ -1,0 +1,35 @@
+'''
+Created on Nov 20, 2018
+
+@author: gsnyder
+
+Find all project-versions that have a given word in their notes field
+'''
+
+import argparse
+import csv
+
+from blackduck.HubRestApi import HubInstance
+
+
+parser = argparse.ArgumentParser(description="A program to find all project-versions with a given word in their Notes field and write the project, version names to a file")
+parser.add_argument("file", help="The file to write the project and version names into")
+parser.add_argument("word", help="The project-version phase")
+args = parser.parse_args()
+
+hub = HubInstance()
+
+projects = hub.get_projects()
+
+if 'items' in projects:
+	with open(args.file, 'w', newline='') as csvfile:
+		project_versions_writer = csv.writer(csvfile)
+		for project in projects['items']:
+			versions = hub.get_project_versions(project)
+			if 'totalCount' in versions and versions['totalCount'] > 0:
+				for version in versions['items']:
+					if 'releaseComments' in version and args.word.lower() in version['releaseComments'].lower():
+						project_versions_writer.writerow([
+							project['name'], 
+							version['versionName']
+						])


### PR DESCRIPTION
This program will dump the project and version names for any project-version that has the given word in the Notes field. Using this in conjunction with another program that will delete project-versions (and their scans) given a list of project, version names in a CSV file.