### PR TITLE
"hub" should be "self"

### DIFF
--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -512,7 +512,7 @@ class HubInstance(object):
     def get_component_remediation(self, bom_component):
         url = "{}/remediating".format(bom_component['componentVersion'])
         logging.debug("Url for getting remediation info is : {}".format(url))
-        response = hub.execute_get(url)
+        response = self.execute_get(url)
         return response.json()
 
     ##


### PR DESCRIPTION
HubRestApi.py", line 515, in get_component_remediation
    response = hub.execute_get(url)
NameError: name 'hub' is not defined