### PR TITLE
Fix to typo in get_project_info()

### DIFF
--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -1139,7 +1139,7 @@ class HubInstance(object):
 
     def get_project_info(self, project_name, link_name):
         project = self.get_project_by_name(project_name)
-        link = self.get_link(project, link_name)
+        link = self.get_link(project_name, link_name)
         if link:
             response = self.execute_get(link)
             return response.json()


### PR DESCRIPTION
Incorrect variable name caused calls to this and connected functions to fail.