### PR TITLE
addding exmple code to poll for bom completed notifications and create 'fix me' messages

### DIFF
--- a/examples/create_fix_it_message.py
+++ b/examples/create_fix_it_message.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+import argparse
+from datetime import datetime
+import logging
+import json
+import sys
+
+parser = argparse.ArgumentParser("Process the JSON output from get_bom_component_policy_violations.py to create a FIX IT message that guides the project team how to resolve the issues identified through policy rule violations")
+parser.add_argument("-f", "--policy_violations_file", help="By default, program reads JSON doc from stdin, but you can alternatively give a file name")
+parser.add_argument("-o", "--output_file", help="By default, the fix it message is written to stdout. Use this option to instead write to a file")
+
+args = parser.parse_args()
+
+logging.basicConfig(format='%(asctime)s%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+if args.policy_violations_file:
+    with open(args.policy_violations_file, 'r') as pvf:
+        policy_violations = json.load(pvf)
+else:
+    policy_violations = json.load(sys.stdin)
+
+project_name = policy_violations['project']['name']
+version_label = policy_violations['version']['versionName']
+version_url = policy_violations['version']['_meta']['href']
+version_license = policy_violations['version']['license']['licenseDisplay']
+if version_license.lower() == "unknown license":
+    license_statement = """This project version does not appear to have a declared license. 
+        You should probably declare one.. You can find more info on how to choose the appropriate license
+        for your project <a href=https://our-company/choosing-license>here</a>"""
+else:
+    license_statement = "This project version is governed by the {} license.".format(version_license)
+
+html = """
+<html>
+    <body>
+        <p>This is a summary of the policy violations found in project {}, version {}. It was created {}. 
+        This summary provides guidance on what to do to resolve these violations. </p>
+        <p>{}</p> 
+        <p>You can view the project version and more details regarding it
+        on Black Duck <a href={}>here</a></p>
+        <p>For more information on SCA (Software Composition Analysis) and 
+        how it fits into our SDLC go to <a href=https://our-company/sca-info>https://our-company/sca-info</a></p>
+
+        <table border=1>
+            <tr>
+                <th>Component</th>
+                <th>Version</th>
+                <th>Component License</th>
+                <th>URL</th>
+                <th>Violation</th>
+                <th>Guidance to Fix</th>
+                <th>Overrideable</th>
+                <th>Severity</th>
+            </tr>
+""".format(project_name, version_label, datetime.now(), license_statement, version_url)
+
+del policy_violations['project']
+del policy_violations['version']
+
+for violation_info in policy_violations.values():
+    component_name = violation_info['bom_component']['componentName']
+    component_version = violation_info['bom_component'].get('componentVersionName')
+    component_url = violation_info['bom_component']['component']
+    # if component-version URL is available use it, but if not revert to the component URL
+    component_version_url = violation_info['bom_component'].get('componentVersion', component_url)
+    component_license = ",".join([l['licenseDisplay'] for l in violation_info['bom_component']['licenses']])
+    policies_in_violation = violation_info['policies_in_violation']['totalCount']
+    for policy_violation in violation_info['policies_in_violation']['items']:
+        pv_name = policy_violation['name']
+        pv_description = policy_violation['description']
+        overridable = policy_violation['overridable']
+        severity = policy_violation['severity']
+        html += """
+            <tr>
+                <td>{}</td>
+                <td>{}</td>
+                <td>{}</td>
+                <td><a href={}>click here to view more info on this component from Black Duck</a></td>
+                <td>{}</td>
+                <td>{}</td>
+                <td>{}</td>
+                <td>{}</td>
+            </tr>
+        """.format(component_name, component_version, component_license, component_version_url, pv_name, pv_description, overridable, severity)
+
+html += """
+        </table>
+    </body>
+</html>
+"""
+
+if args.output_file:
+    output_file = open(args.output_file, 'w')
+else:
+    output_file = sys.stdout
+
+output_file.write(html)
+
+
+

--- a/examples/get_bom_component_policy_violations.py
+++ b/examples/get_bom_component_policy_violations.py
@@ -9,9 +9,11 @@ import sys
 from blackduck.HubRestApi import HubInstance
 
 
-parser = argparse.ArgumentParser("Retreive BOM components for the given project and version")
-parser.add_argument("project_name")
-parser.add_argument("version")
+parser = argparse.ArgumentParser("Retreive BOM components for the given project and version by giving project/version names OR using a version URL")
+mutually_xgroup = parser.add_mutually_exclusive_group()
+mutually_xgroup.add_argument("-p", "--project_name")
+mutually_xgroup.add_argument("-u", "--url")
+parser.add_argument("-v", "--version", required="-p" in sys.argv or "--project_name" in sys.argv)
 
 args = parser.parse_args()
 
@@ -21,12 +23,19 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 hub = HubInstance()
 
-project = hub.get_project_by_name(args.project_name)
-version = hub.get_version_by_name(project, args.version)
+if args.url:
+    project_url = "/".join(args.url.split("/")[:-2])
+    project = hub.execute_get(project_url).json()
+    version = hub.execute_get(args.url).json()
+else:
+    project = hub.get_project_by_name(args.project_name)
+    version = hub.get_version_by_name(project, args.version)
 
 bom_components = hub.get_version_components(version)
 
 all_policy_violations = dict()
+
+all_policy_violations.update({'project': project, 'version': version})
 
 for bom_component in bom_components.get('items'):
     if bom_component.get('policyStatus') == "IN_VIOLATION":

--- a/examples/get_bom_computed_notifications.py
+++ b/examples/get_bom_computed_notifications.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+'''
+Created on Feb 21, 2020
+
+@author: gsnyder
+
+Retrieve BOM computed notifications
+
+Note: The user account you run this under will determine the scope (i.e. projects, versions) of 
+the notifications that can be received.
+
+'''
+
+# TODO: Use startDate filter on /api/notifications to limit the notifications retrieved when using -n
+
+import argparse
+from datetime import datetime
+import json
+import logging
+import pytz
+import sys
+import timestring
+
+from terminaltables import AsciiTable
+
+from blackduck.HubRestApi import HubInstance, object_id
+
+#
+# Example usage:
+#
+#   To get all the vulnerability notices,
+#       python examples/get_vulnerability_notifications.py > all_vuln_notifications.json
+#
+#   To get all the vulnerability notices and save the date/time of the last run,
+#       python examples/get_vulnerability_notifications.py -s > all_vuln_notifications.json
+#
+#   To get all the vulnerability notices since the last run,
+#       python examples/get_vulnerability_notifications.py -n `cat .last_run` > all_vuln_notifications.json
+#
+#   To get all the vulnerability notices since a date/time,
+#       python examples/get_vulnerability_notifications.py -n "March 29, 2019 12:00" > since_mar_29_at_noon_vuln_notifications.json
+#
+#   To get all the vulnerability notices for a given project,
+#       python examples/get_vulnerability_notifications.py -p my-project > all_vuln_notifications_for_my_project.json
+#
+#   To get all the vulnerability notices for a given project and version,
+#       python examples/get_vulnerability_notifications.py -p my-project -v 1.0 > all_vuln_notifications_for_my_project_v1.0.json
+#
+#
+
+
+parser = argparse.ArgumentParser("Retreive BOM computed notifications")
+parser.add_argument("-p", "--project", help="If supplied, filter the notifications to this project")
+parser.add_argument("-v", "--version", help="If supplied, filter the notifications to this version (requires a project)")
+parser.add_argument("-n", "--newer_than", 
+    default=None, 
+    type=str,
+    help="Set this option to see all vulnerability notifications published since the given date/time.")
+parser.add_argument("-d", "--save_dt", 
+    action='store_true', 
+    help="If set, the date/time will be saved to a file named '.last_run' in the current directory which can be used later with the -n option to see vulnerabilities published since the last run.")
+parser.add_argument("-l", "--limit", default=100000, help="To change the limit on the number of notifications to retrieve")
+parser.add_argument("-s", "--system", action='store_true', help="Pull notifications from the system as opposed to the user's account")
+args = parser.parse_args()
+
+if args.newer_than:
+    newer_than = timestring.Date(args.newer_than).date
+    # adjust to UTC so the comparison is normalized
+    newer_than = newer_than.astimezone(pytz.utc)
+else:
+    newer_than = None
+
+if args.save_dt:
+    with open(".last_run", "w") as f:
+        f.write(datetime.now().isoformat())
+
+logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+hub = HubInstance()
+current_user = hub.get_current_user()
+
+# Construct the URL to either pull from the system or user account scope,
+# and then narrow the search to only include BOM computed
+if args.system:
+    notifications_url = "{}/api/notifications".format(hub.get_urlbase())
+else:
+    notifications_url = hub.get_link(current_user, "notifications")
+
+notifications_url = "{}?limit={}&filter=notificationType:VERSION_BOM_CODE_LOCATION_BOM_COMPUTED".format(
+    notifications_url, args.limit)
+
+if newer_than:
+    start_date = newer_than.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    notifications_url += "&startDate=" + start_date
+
+bom_computed_notifications = hub.execute_get(notifications_url).json().get('items', [])
+
+# if newer_than:
+#     bom_computed_notifications = list(
+#         filter(lambda n: timestring.Date(n['createdAt']) > newer_than, bom_computed_notifications))
+if args.project:
+    bom_computed_notifications = list(
+        filter(lambda n: args.project in [apv['projectName'] for apv in n['content']['affectedProjectVersions']], 
+            bom_computed_notifications))
+    if args.version:
+        bom_computed_notifications = list(
+            filter(lambda n: args.version in [apv['projectVersionName'] for apv in n['content']['affectedProjectVersions']], 
+                bom_computed_notifications))
+
+print(json.dumps(bom_computed_notifications))

--- a/examples/get_snippet_match_counts.py
+++ b/examples/get_snippet_match_counts.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import logging
+import sys
+from pprint import pprint
+
+from blackduck.HubRestApi import HubInstance, object_id
+
+parser = argparse.ArgumentParser("Retrieve snippet match counts for a given project-version")
+parser.add_argument("project_name")
+parser.add_argument("version")
+
+args = parser.parse_args()
+
+logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+hub = HubInstance()
+
+version = hub.get_project_version_by_name(args.project_name, args.version)
+
+snippet_counts_url = version['_meta']['href'] + "/snippet-counts"
+
+snippet_counts = hub.execute_get(snippet_counts_url).json()
+
+del snippet_counts['_meta']
+
+print("Snippet count info for project {}, version {}:".format(args.project_name, args.version))
+pprint(snippet_counts)

--- a/examples/poll_for_bom_computed_notifications.bash
+++ b/examples/poll_for_bom_computed_notifications.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+# set -x
+# invoke from root of repository, e.g.
+# 	cd repo_dir
+# 	./examples/poll_for_bom_computed_notifications.bash
+#
+
+while true
+do
+	echo "polling for bom computed notifications to create fix it messages for the project-versions"
+	if [ -f ".last_run" ]
+	then
+		OPTIONS="-n $(cat .last_run) -d"
+	else
+		OPTIONS="-n $(date +"%Y-%m-%dT%H:%M:%SZ") -d"
+	fi
+	python examples/get_bom_computed_notifications.py ${OPTIONS} |
+	python examples/project_version_urls_from_bom_computed_notifications.py | 
+	while read url
+	do
+		echo "Processing BOM to produce a fix it message for url $url" >&2
+		python examples/get_bom_component_policy_violations.py -u $url |
+		python examples/create_fix_it_message.py -o $(basename $url).html
+		echo "Wrote fix it message to $(basename $url).html"
+	done
+	sleep 5
+done

--- a/examples/project_version_urls_from_bom_computed_notifications.py
+++ b/examples/project_version_urls_from_bom_computed_notifications.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+import json
+import sys
+
+parser = argparse.ArgumentParser("Process the JSON output from get_bom_component_policy_violations.py to create a FIX IT message that guides the project team how to resolve the issues identified through policy rule violations")
+parser.add_argument("-f", "--policy_violations_file", help="By default, program reads JSON doc from stdin, but you can alternatively give a file name")
+parser.add_argument("-o", "--output_file", help="By default, the fix it message is written to stdout. Use this option to instead write to a file")
+
+args = parser.parse_args()
+
+logging.basicConfig(format='%(asctime)s%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+bom_computed_notifications = json.load(sys.stdin)
+bom_computed_notifications = sorted(bom_computed_notifications, key=lambda n: n['createdAt'])
+
+for bom_computed_notification in bom_computed_notifications:
+    project_version_url = bom_computed_notification['content']['projectVersion']
+    # created_at = bom_computed_notification['createdAt']
+    print(project_version_url)


### PR DESCRIPTION
The sample code shows how to:
1. Poll for BOM completed notifications, i.e. notifications that processing of the BOM for a project-version was completed, presumably cause a new scan was done
1. Get all the policy violations for the affected project-versions, and
1. With that information, generate a nicely formatted HTML message that instructs the developer(s) what they need to fix

Note that the 'fix me' message draws content from the policy rule fields to instruct the developer, so a prerequisite is to setup your policy rules, and their description fields, to include the appropriate content. For instance, in a policy rule that flags any/all components having high severity vulnerabilities you would put in the rule description whatever steps the developer should take to remediate the issue.