### PR TITLE
Create a hotfix for TypeError when using --phase argument

### DIFF
--- a/.restconfig.json
+++ b/.restconfig.json
@@ -1,0 +1,6 @@
+{
+   "baseurl": "https://blackduck.test.maerskdev.net/",
+   "api_token": "NThmZTA3MGUtNWJkZi00ZjlhLWIzZjgtZjFhYjNhOGQwYTM0OjAxYmRhOTU4LTJmZjctNDdhMy1iNDAzLTM2YThlYWI4N2U1ZQ==",
+   "insecure": true,
+   "debug": false
+}

--- a/examples/get_project_versions.py
+++ b/examples/get_project_versions.py
@@ -65,8 +65,8 @@ if 'totalCount' in project_list and project_list['totalCount'] > 0:
 
 			if args.phase:
 				new_list = list()
-				for idx, version in enumerate(sorted_version_list):
-					if sorted_version_list[idx]['phase'] == phase_map[args.phase]:
+				for version in sorted_version_list:
+					if version['phase'] == phase_map[args.phase]:
 						new_list.append(version)
 				sorted_version_list = new_list
 			if args.limit:

--- a/examples/get_project_versions.py
+++ b/examples/get_project_versions.py
@@ -65,8 +65,8 @@ if 'totalCount' in project_list and project_list['totalCount'] > 0:
 
 			if args.phase:
 				new_list = list()
-				for version in sorted_version_list:
-					if sorted_version_list['phase'] == phase_map[args.phase]:
+				for idx, version in enumerate(sorted_version_list):
+					if sorted_version_list[idx]['phase'] == phase_map[args.phase]:
 						new_list.append(version)
 				sorted_version_list = new_list
 			if args.limit:


### PR DESCRIPTION
python examples/get_project_versions.py my-project-name --phase 'In Development'

It will error out with TypeError: list indices must be integers or slices, not str

That has now been fixed by using enumeration()