### PR TITLE
fixed use of hard-coded values for the verify parameter being supplied to requests calls

### DIFF
--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -1307,11 +1307,11 @@ class HubInstance(object):
         if filename.endswith('.json') or filename.endswith('.jsonld'):
             headers['Content-Type'] = 'application/ld+json'
             with open(filename,"r") as f:
-                response = requests.post(url, headers=headers, data=f, verify=False)
+                response = requests.post(url, headers=headers, data=f, verify=not self.config['insecure'])
         elif filename.endswith('.bdio'):
             headers['Content-Type'] = 'application/vnd.blackducksoftware.bdio+zip'
             with open(filename,"rb") as f:
-                response = requests.post(url, headers=headers, data=f, verify=False)
+                response = requests.post(url, headers=headers, data=f, verify=not self.config['insecure'])
         else:
             raise Exception("Unkown file type")
         return response
@@ -1338,7 +1338,7 @@ class HubInstance(object):
                     if not os.path.exists(project_name):
                         os.mkdir(project_name)
                     pathname = os.path.join(project_name, filename)
-                responce = requests.get(url, headers=self.get_headers(), stream=True, verify=False)
+                responce = requests.get(url, headers=self.get_headers(), stream=True, verify=not self.config['insecure'])
                 with open(pathname, "wb") as f:
                     for data in responce.iter_content():
                         f.write(data)

--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 52)
+VERSION = (0, 0, 53)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
Two methods, upload_scan and download_project_scans, used hardcoded values (False) for the verify parameter used by the requests module to enforce secure (SSL) connections. The corrections here take the value from a configuration file that the user (of blackduck library) uses to specify whether to enforce secure connections or not.