### PR TITLE
adding support for invoking the option to include (or exclude) additional copyright information from notices file report

### DIFF
--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -560,15 +560,17 @@ class HubInstance(object):
         return self.execute_post(version_reports_url, post_data)
 
     valid_notices_formats = ["TEXT", "JSON"]
-    def create_version_notices_report(self, version, format="TEXT"):
+    def create_version_notices_report(self, version, format="TEXT", include_copyright_info=True):
         assert format in HubInstance.valid_notices_formats, "Format must be one of {}".format(HubInstance.valid_notices_formats)
 
         post_data = {
-            'categories': ["COPYRIGHT_TEXT"],
-            'versionId': version['_meta']['href'].split("/")[-1],
+            'versionId': object_id(version),
             'reportType': 'VERSION_LICENSE',
             'reportFormat': format
         }
+        if include_copyright_info:
+            post_data.update({'categories': ["COPYRIGHT_TEXT"] })
+
         notices_report_url = self.get_link(version, 'licenseReports')
         return self.execute_post(notices_report_url, post_data)
 

--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 53)
+VERSION = (0, 0, 54)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/examples/generate_notices_report_for_project_version.py
+++ b/examples/generate_notices_report_for_project_version.py
@@ -23,6 +23,7 @@ parser.add_argument("version_name")
 
 parser.add_argument('-f', "--file_name_base", default="notices_report", help="Base file name to write the report data into. If the report format is TEXT a .zip file will be created, otherwise a .json file")
 parser.add_argument('-r', '--report_format', default='TEXT', choices=["JSON", "TEXT"], help="Report format - choices are TEXT or HTML")
+parser.add_argument('-c', '--include_copyright_info', action='store_true', help="Set this option to have additional copyright information from the Black Duck KB included in the notices file report.")
 
 args = parser.parse_args()
 
@@ -66,7 +67,7 @@ project = hub.get_project_by_name(args.project_name)
 if project:
 	version = hub.get_version_by_name(project, args.version_name)
 
-	response = hub.create_version_notices_report(version, args.report_format)
+	response = hub.create_version_notices_report(version, args.report_format, include_copyright_info=args.include_copyright_info)
 
 	if response.status_code == 201:
 		logging.info("Successfully created notices report in {} format for project {} and version {}".format(


### PR DESCRIPTION
When generating a notices file report there is an option (in the Black Duck GUI) for including the (additional) copyright information from the Black Duck KB. In the GUI this option is off by default. In HubRestApi.py the method for generating the notices file report has the option on by default. As a first step I added a parameter that allows the caller to set the value for this to False, but I set it to True to maintain the current behavior.

Additionally, in the sample program showing how to generate a notices file I've added an option that allows the user to decide whether to include the copyright information, or not. Default is to not include the additional copyright information.