### PR TITLE
Enabled persistent HTTP connection and fix get_version_by_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.restconfig.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .restconfig.json
+synamedia
+synamedia/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,109 +1,72 @@
 ## Overview ##
 The hub-rest-api-python provides Python bindings for Hub REST API.
 
-## To use
+This is the Synamedia fork of this Open Source repository. The default branch is synamedia. The master branch is the original repo default branch.
 
 ```
-pip install blackduck
-```
-
-```python
-from blackduck.HubRestApi import HubInstance
-import json
-
-username = "sysadmin"
-password = "your-password"
-urlbase = "https://ec2-34-201-23-208.compute-1.amazonaws.com"
-
-hub = HubInstance(urlbase, username, password, insecure=True)
-
-projects = hub.get_projects()
-
-print(json.dumps(projects.get('items', [])))
-```
-
-### Examples
-
-Example code showing how to do various things can be found in the *examples* folder. 
-
-## Build ##
-
-You should be using [virtualenv](https://pypi.org/project/virtualenv/), [virtrualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) to make things easy on yourself.
-
-Ref: [Packaging Python Projects Tutorial](https://packaging.python.org/tutorials/packaging-projects/)
-
-### Build the blackduck packages
-To build both the source distribution package and the wheel package,
-
-```
-pip3 install -r requirements.txt
-python3 setup.py sdist bdist_wheel
-```
-
-### Distribute the package
-
-Requires you have an account on either/both [PyPi](https://pypi.org) and [Test PyPi](https://test.pypi.org) *AND* you must be a package maintainer.
-
-Send a request to gsnyder@synopsys.com or gsnyder2007@gmail.com if you want to be listed as a package maintainer.
-
-#### To PyPi
-
-Upload to PyPi,
-
-```
-twine upload dist/*
-```
-
-Then try installing it from PyPy
-
-```
-pip install blackduck
-```
-
-#### To Test PyPi
-
-Upload to Test PyPi,
-
-```
-twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-```
-
-Then try installing it from Test PyPy
-
-```
-pip install --index-url https://test.pypi.org/simple/ blackduck
-```
-
-### Install package locally
-
-Do this when testing a new version.
-
-```
-git clone https://github.com/blackducksoftware/hub-rest-api-python.git
+git clone https://github.com/synamedia/hub-rest-api-python.git
 cd hub-rest-api-python
 pip3 install -r requirements.txt
 pip3 install .
 ```
+## Generate reports
+### Common usage example
+`python3 generate_reports.py --project_name <your project> --summary short --detailed --licence --output <path>`
 
-## Test ##
-Using (pytest)[https://pytest.readthedocs.io/en/latest/contents.html]
-
-```bash
-git clone https://github.com/blackducksoftware/hub-rest-api-python.git
-cd hub-rest-api-python
-# optional but advisable: create/use virtualenv
-# you should have 3.x+, e.g. Python 3.7.0
-
-pip3 install -r requirements.txt
-pip3 install .
-cd test
-pytest
+### Usage
 ```
+$ ./generate_reports.py --help
+usage: generate_reports.py [-h]
+                           (--project_name PROJECT_NAME | --project_file PROJECT_FILE)
+                           [--version VERSION] [--summary {short,full}]
+                           [--detailed] [--licence] [--output OUTPUT]
+                           [--format {CSV,JSON}] [--skip_cleanup]
+                           [--prefix PREFIX] [--sleep_time SLEEP_TIME] [--log]
 
-## Where can I get the latest release? ##
-This package is available on PyPi,
+Generates and downloads reports for project(s) on blackduck.com
 
-`pip3 install blackduck`
+optional arguments:
+  -h, --help            show this help message and exit
+  --project_name PROJECT_NAME, -p PROJECT_NAME
+                        Add a single project
+  --project_file PROJECT_FILE, -f PROJECT_FILE
+                        Add all projects listed in the file
+  --version VERSION, -v VERSION
+                        Version to use if not specified in the file. Default:
+                        master
+  --output OUTPUT, -o OUTPUT
+                        Output folder to download the reports into. Default: .
+  --format {CSV,JSON}, -m {CSV,JSON}
+                        Report format. 1 JSON file or multiple CSV files
+  --skip_cleanup, -c    Do not remove reports generated on BlackDuck
+  --prefix PREFIX, -x PREFIX
+                        String to add to the start of all project names
+  --sleep_time SLEEP_TIME, -t SLEEP_TIME
+                        Time in seconds to sleep between download attempts
+  --log                 Debug log output
+
+reports:
+  Select 1 or more to generate
+
+  --summary {short,full}, -s {short,full}
+                        Create a summary report json file of the project(s).
+                        short option only lists the CRITICAL and HIGH issues.
+  --detailed, -d        Generate and fetch the detailed reports.
+  --licence, -l         Generate and fetch the licence report (aka Notices
+                        file).
+
+Note: When using the --project_file option the file format per line MUST be:
+
+# Lines starting # are ignored, so are empty lines
+project name[;version][;filename]
+
+# The default version is master but can be overridden with --version
+# The default filenema is the project-version name with .zip e.g. "my proj-master.zip" 
+```
+## Rename user groups
+BlackDuck does sync with Azure but it does not bring the security group names in, only the GUIDs are displayed. To fix that we need to get a dump of [groups from Azure](https://portal.azure.com/#blade/Microsoft_AAD_IAM/GroupsManagementMenuBlade/AllGroups) but **Download groups** is greyed out for normal users. So we need to ask an Azure admin e.g. Natan Kahana. Once we have the file we can apply the correct group names to BlackDuck.
+### Example
+`./rename_user_groups.py --file c__temp_exportGroup_2020-8-12.csv`
 
 ## Documentation ##
 Documentation for hub-rest-api-python can be found on the base project:  [Hub REST API Python Wiki](https://github.com/blackducksoftware/hub-rest-api-python/wiki)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip3 install -r requirements.txt
 pip3 install .
 ```
 ### Configure your connection
-Create a token in BlackDuck for your user (generica account)
+Create a token in BlackDuck for your user or generic account
 
 `cp restconfig.json.api_token.example restconfig.json`
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ cd hub-rest-api-python
 pip3 install -r requirements.txt
 pip3 install .
 ```
+### Configure your connection
+Create a token in BlackDuck for your user (generica account)
+
+`cp restconfig.json.api_token.example restconfig.json`
+
+Update restconfig.json with your credentials
+
 ## Generate reports
 ### Common usage example
 `python3 generate_reports.py --project_name <your project> --summary short --detailed --licence --output <path>`

--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -552,15 +552,18 @@ class HubInstance(object):
         return self.execute_post(version_reports_url, post_data)
 
     valid_notices_formats = ["TEXT", "JSON"]
-    def create_version_notices_report(self, version, format="TEXT"):
+    def create_version_notices_report(self, version, format="TEXT", copyright_text=False):
         assert format in HubInstance.valid_notices_formats, "Format must be one of {}".format(HubInstance.valid_notices_formats)
 
         post_data = {
-            'categories': ["COPYRIGHT_TEXT"],
             'versionId': version['_meta']['href'].split("/")[-1],
             'reportType': 'VERSION_LICENSE',
             'reportFormat': format
         }
+        
+        if copyright_text:
+            post_data['categories'] = ["COPYRIGHT_TEXT"]
+            
         notices_report_url = self.get_link(version, 'licenseReports')
         return self.execute_post(notices_report_url, post_data)
 

--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -238,8 +238,8 @@ class HubInstance(object):
     def get_roles(self, parameters={}):
         url = self._get_role_url() + self._get_parameter_string(parameters)
         response = self.execute_get(url)
-        return response.json()
-
+        return response.json()  
+    
     def get_roles_url_from_user_or_group(self, user_or_group):
         # Given a user or user group object, return the 'roles' url
         roles_url = None
@@ -1066,6 +1066,20 @@ class HubInstance(object):
         else:
             logging.warning("Did not find a project by the name {}".format(project_name))
 
+    def delete_user_group_from_project(self, project_name, user_group_name):
+        project = self.get_project_by_name(project_name)
+        
+        if project:
+            project_url = project['_meta']['href']
+            
+            user_group = self.get_user_group_by_name(user_group_name)
+            if user_group:
+                user_group_url = user_group['_meta']['href']
+                user_group_id = user_group_url.rsplit('/', 1)[-1]
+            
+                project_user_group_url = f"{project_url}/usergroups/{user_group_id}"
+                self.execute_delete(project_user_group_url)    
+    
     def assign_user_to_project(self, user_name, project_name, project_roles, limit=1000):
         # Assign users to projects
         project = self.get_project_by_name(project_name)

--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -530,7 +530,7 @@ class HubInstance(object):
     #
     ##
 
-    valid_categories = ['VERSION','CODE_LOCATIONS','COMPONENTS','SECURITY','FILES']
+    valid_categories = ['VERSION','CODE_LOCATIONS','COMPONENTS','SECURITY','FILES', 'ATTACHMENTS', 'CRYPTO_ALGORITHMS', 'PROJECT_VERSION_CUSTOM_FIELDS', 'BOM_COMPONENT_CUSTOM_FIELDS', 'LICENSE_TERM_FULFILLMENT']
     valid_report_formats = ["CSV"]
     def create_version_reports(self, version, report_list, format="CSV"):
         assert all(list(map(lambda k: k in HubInstance.valid_categories, report_list))), "One or more selected report categories in {} are not valid ({})".format(

--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -369,8 +369,8 @@ class HubInstance(object):
         return response.json()
 
     def get_user_group_by_name(self, group_name):
-        groups = self.get_user_groups()
-        for group in groups['items']:
+        group_list = self.get_user_groups({"q": f"name:{group_name}"})
+        for group in group_list['items']:
             if group['name'] == group_name:
                 return group
 
@@ -1022,7 +1022,7 @@ class HubInstance(object):
             project_url = project['_meta']['href']
             assignable_user_groups_link = self.get_link(project, 'assignable-usergroups')
             if assignable_user_groups_link:
-                assignable_user_groups_response = self.execute_get(assignable_user_groups_link)
+                assignable_user_groups_response = self.execute_get(f"{assignable_user_groups_link}?q=name:{user_group_name}")
                 assignable_user_groups = assignable_user_groups_response.json()
 
                 # TODO: What to do if the user group is already assigned to the project, and therefore
@@ -1060,7 +1060,7 @@ class HubInstance(object):
                 else:
                     assignable_groups = [u['name'] for u in assignable_user_groups['items']]
                     logging.warning("The user group {} was not found in the assignable user groups ({}) for this project {}. Is the group already assigned to this project?".format(
-                        user_group_name, assignable_groups, project_name))
+                        user_group_name['name'], assignable_groups, project_name))
             else:
                 logging.warning("This project {} has no assignable user groups".format(project_name))
         else:

--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -531,7 +531,7 @@ class HubInstance(object):
     ##
 
     valid_categories = ['VERSION','CODE_LOCATIONS','COMPONENTS','SECURITY','FILES', 'ATTACHMENTS', 'CRYPTO_ALGORITHMS', 'PROJECT_VERSION_CUSTOM_FIELDS', 'BOM_COMPONENT_CUSTOM_FIELDS', 'LICENSE_TERM_FULFILLMENT']
-    valid_report_formats = ["CSV"]
+    valid_report_formats = ["CSV", "JSON"]
     def create_version_reports(self, version, report_list, format="CSV"):
         assert all(list(map(lambda k: k in HubInstance.valid_categories, report_list))), "One or more selected report categories in {} are not valid ({})".format(
             report_list, HubInstance.valid_categories)

--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 51)
+VERSION = (0, 0, 52)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 50)
+VERSION = (0, 0, 51)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/create_project.py
+++ b/create_project.py
@@ -1,0 +1,133 @@
+
+import argparse
+import json
+
+from blackduck.HubRestApi import HubInstance
+
+# ------------------------------------------------------------------------------
+# Parse command line
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description='Creates project(s) in synamedia.app.blackduck.com',
+    epilog='''\
+Note: When using the --project_file option the file format per line MUST be:
+
+# Lines starting # are ignored, so are empty lines
+project name[;group1[,group2,...,groupN]][;description][;version]
+'''
+)
+
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--project_name', '-p', type=str, help='Add a single project')
+group.add_argument('--project_file', '-f', type=argparse.FileType(), help='Add all projects listed in the file')
+
+parser.add_argument('--group', '-g', type=str, required=True, help='Default group to use (normally SAML). Optionally overridden when using a file.' )
+
+parser.add_argument('--prefix', default='', type=str, help='String to add to the start of the project name')
+parser.add_argument('--version', '-v', default='master', type=str, help='Version to use if not specified in the file')
+parser.add_argument('--description', '-d', default='', type=str, help='Default description for all projects')
+
+args = parser.parse_args()
+
+
+# ------------------------------------------------------------------------------
+# Functions
+   
+def get_user_groups(names=[]):
+    #print(f"Getting groups: {names}")
+    groups = []
+    for name in names:
+        if name == args.group:
+            group = default_group
+        else:
+            group = hub.get_user_group_by_name(name)
+            if not group:
+                print(f"Unable to find group: {name}")
+                return None
+        
+        groups.append(group['name'])
+    return groups
+
+
+def create_project_with_groups(name=str, version=str, description=str, groups=[]):
+    #print(f"create_project_with_groups({name}, {version}, {description}, {groups})")
+    if not groups:
+        groups = [args.group]
+    else:
+        groups = get_user_groups(groups)
+        if groups is None:
+            return False, "Failed to find group"
+
+    if args.prefix:
+        name = f"{args.prefix} {name}"
+        
+    #print(f"Creating project: {name}")        
+    response = hub.create_project(name, version, parameters = {
+		'description': description
+	})
+    
+    if response and response.status_code == 201:
+        # Attach the user group(s) to the new project
+        for group in groups:
+            response = hub.assign_user_group_to_project(name, group, [])
+            if not response or response.status_code != 201:
+                print(f"WARNING: Failed to assign group {group} to project {name}")
+        
+        return True, f"Created project: {name}"
+        
+    if response.status_code == 412:
+        return False, f"Project already exists: {name}"
+        
+    return False, f"Failed to create project: {name} : {response}"
+        
+        
+# ------------------------------------------------------------------------------  
+# Main code
+
+hub = HubInstance()
+default_group = hub.get_user_group_by_name(args.group)
+if default_group is None:
+    raise SystemExit(f"Unable to find default group: ${args.group}")
+#print(f"default_group: {default_group}")    
+
+if args.project_name is not None:
+    print(f"Adding the single project: {args.project_name}")
+    status, response = create_project_with_groups(args.project_name, args.version, args.description)
+    if status == False:
+        raise SystemExit(f"FATAL: {response}")
+    else:
+        print(response)
+else:
+    f = args.project_file
+    print(f"Parsing the projects file: {f.name}")
+    for line in f.readlines():
+        line = line.strip()
+        if not line or line[0] == "#":
+            continue
+        
+        #print(f">> {line}")
+        params = line.split(";")
+        options = {'project_name':'', 'groups': [args.group], 'description': args.description, 'version':args.version}
+        option_names = list(options)
+        index=0
+        for param in params:
+            if index >= len(option_names):
+                break
+            
+            if option_names[index] == "groups":
+                param = param.split(",")
+                if len(param) == 1 and not param[0]:
+                    param = None
+            
+            if param:
+                options[option_names[index]] = param
+                
+            index += 1
+
+        #print(options)
+        status, response = create_project_with_groups(options['project_name'], options['version'], options['description'], options['groups'])
+        if status == False:
+            print(f"ERROR: {response}")
+        else:
+            print(response)

--- a/create_project.py
+++ b/create_project.py
@@ -1,20 +1,23 @@
+#!/usr/bin/python3 
 
 import argparse
 import json
 
 from blackduck.HubRestApi import HubInstance
 
+const_project_roles = [ "Project Code Scanner", "BOM Manager", "Project Viewer", "Project Manager", "Security Manager", "Policy Violation Reviewer"]
+
 # ------------------------------------------------------------------------------
 # Parse command line
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    description='Creates project(s) in synamedia.app.blackduck.com',
+    description='Creates project(s) on blackduck.com',
     epilog='''\
 Note: When using the --project_file option the file format per line MUST be:
 
 # Lines starting # are ignored, so are empty lines
-project name[;group1[,group2,...,groupN]][;description][;version]
+project name[;group1[,group2,...,groupN]][;description][;version][;project_role1[,project_role2,...,project_roleN]]
 '''
 )
 
@@ -27,6 +30,8 @@ parser.add_argument('--group', '-g', type=str, required=True, help='Default grou
 parser.add_argument('--prefix', default='', type=str, help='String to add to the start of the project name')
 parser.add_argument('--version', '-v', default='master', type=str, help='Version to use if not specified in the file')
 parser.add_argument('--description', '-d', default='', type=str, help='Default description for all projects')
+parser.add_argument('--project_roles', '-r', default='all', type=str, help=f"List of Project Roles to apply (default 'all'), or 'none' from {const_project_roles}")
+parser.add_argument('--update', '-u', action="store_true", help="Existing project(s) are updated rather than skipped")
 
 args = parser.parse_args()
 
@@ -49,8 +54,28 @@ def get_user_groups(names=[]):
         groups.append(group['name'])
     return groups
 
+def parse_project_roles(project_roles_str=str):
+    if project_roles_str == 'none':
+        project_roles = []   
+    elif project_roles_str == 'all':
+        project_roles = const_project_roles
+    else:
+        role_names = project_roles_str.split(",")
+        for role_name in role_names:
+            if role_name not in const_project_roles:
+                return False, f"Invalid Project Role '{role_name}'. Must be one of {const_project_roles}"
+        project_roles = role_names
+    
+    return True, project_roles
 
-def create_project_with_groups(name=str, version=str, description=str, groups=[]):
+def attach_groups_to_project(name, groups, projecct_roles):
+    # Attach the user group(s) to the new project
+    for group in groups:
+        response = hub.assign_user_group_to_project(name, group, project_roles)
+        if not response or response.status_code != 201:
+            print(f"WARNING: Failed to assign group {group} to project {name}")
+                    
+def create_project_with_groups(name=str, version=str, description=str, groups=[], project_roles=[]):
     #print(f"create_project_with_groups({name}, {version}, {description}, {groups})")
     if not groups:
         groups = [args.group]
@@ -67,19 +92,41 @@ def create_project_with_groups(name=str, version=str, description=str, groups=[]
 		'description': description
 	})
     
-    if response and response.status_code == 201:
-        # Attach the user group(s) to the new project
-        for group in groups:
-            response = hub.assign_user_group_to_project(name, group, [])
-            if not response or response.status_code != 201:
-                print(f"WARNING: Failed to assign group {group} to project {name}")
+    if response is not None:
+        if response.status_code == 201:
+            attach_groups_to_project(name, groups, projecct_roles)
+            return True, f"Created project: {name}"
+        elif response.status_code == 412:
+            if args.update:
+                project = hub.get_project_by_name(name)
+                if project:
+                    project_updated = project
+                    project_updated['description'] = description
+                    
+                    # Delete all the current project's user groups
+                    project_url = project['_meta']['href']
+                    project_user_groups_url = f"{project_url}/usergroups"
+                    response = hub.execute_get(project_user_groups_url)
+                    if response:
+                        project_user_groups = response.json()
+                        for group in project_user_groups['items']:
+                            hub.delete_user_group_from_project(name, group['name'])
+                        
+                        # Attach the new list of user groups
+                        attach_groups_to_project(name, groups, project_roles)
+                        hub.update_project_settings(project, project_updated)
+                        return True, f"Updated project: {name}"
+                    return False, f"Project does not exist: {name}"
+                else:
+                    return False, f"Project does not exist: {name}"
+            else:
+                return False, f"Project already exists: {name}"
         
-        return True, f"Created project: {name}"
+        return False, f"Failed to create project: {name} : {response.status_code}"
         
-    if response.status_code == 412:
-        return False, f"Project already exists: {name}"
-        
-    return False, f"Failed to create project: {name} : {response}"
+    return False, f"No response from BlackDuck hub"
+    
+    
         
         
 # ------------------------------------------------------------------------------  
@@ -91,9 +138,13 @@ if default_group is None:
     raise SystemExit(f"Unable to find default group: ${args.group}")
 #print(f"default_group: {default_group}")    
 
+status, project_roles = parse_project_roles(args.project_roles)
+if status == False:
+    raise SystemExit(project_roles)
+
 if args.project_name is not None:
     print(f"Adding the single project: {args.project_name}")
-    status, response = create_project_with_groups(args.project_name, args.version, args.description)
+    status, response = create_project_with_groups(args.project_name, args.version, args.description, args.group.split(","), project_roles)
     if status == False:
         raise SystemExit(f"FATAL: {response}")
     else:
@@ -106,28 +157,43 @@ else:
         if not line or line[0] == "#":
             continue
         
-        #print(f">> {line}")
+        print(f">> {line}")
         params = line.split(";")
-        options = {'project_name':'', 'groups': [args.group], 'description': args.description, 'version':args.version}
+        options = {
+            'project_name':'',
+            'groups': [args.group],
+            'description': args.description,
+            'version': args.version,
+            'project_roles': project_roles,
+            }
         option_names = list(options)
         index=0
+        status = True
         for param in params:
             if index >= len(option_names):
                 break
-            
+
+            print(f">>> param: {param}")
             if option_names[index] == "groups":
                 param = param.split(",")
                 if len(param) == 1 and not param[0]:
                     param = None
+            
+            if option_names[index] == "project_roles":
+                status, param = parse_project_roles(param)
+                if status == False:
+                    print(f"ERROR: {param}. Not creating project {options['project_name']}")
+                    break;
             
             if param:
                 options[option_names[index]] = param
                 
             index += 1
 
-        #print(options)
-        status, response = create_project_with_groups(options['project_name'], options['version'], options['description'], options['groups'])
-        if status == False:
-            print(f"ERROR: {response}")
-        else:
-            print(response)
+        if status:
+            print(options)
+            status, response = create_project_with_groups(options['project_name'], options['version'], options['description'], options['groups'], options['project_roles'])
+            if status == False:
+                print(f"ERROR: {response}")
+            else:
+                print(response)

--- a/examples/generate_csv_reports_for_project_version.py
+++ b/examples/generate_csv_reports_for_project_version.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 '''
 Created on Dec 19, 2018
 
@@ -12,13 +14,26 @@ import argparse
 import json
 import time
 
+version_name_map = {
+	'version': 'VERSION',
+	'scans': 'CODE_LOCATIONS',
+	'components': 'COMPONENTS',
+	'vulnerabilities': 'SECURITY',
+	'source':'FILES',
+    'attachments':'ATTACHMENTS',
+    'crypto':'CRYPTO_ALGORITHMS',
+    'project_custom':'PROJECT_VERSION_CUSTOM_FIELDS',
+    'bom_custom':'BOM_COMPONENT_CUSTOM_FIELDS',
+    'license':'LICENSE_TERM_FULFILLMENT',
+}
+
 parser = argparse.ArgumentParser("A program to create reports for a given project-version")
 parser.add_argument("project_name")
 parser.add_argument("version_name")
 parser.add_argument("-z", "--zip_file_name", default="reports.zip")
 parser.add_argument("-r", "--reports",
-	default="version,scans,components,vulnerabilities,source", 
-	help="Comma separated list (no spaces) of the reports to generate - version, scans, components, vulnerabilities, source, and cryptography reports (default: all, except cryptography")
+	default="version,scans,components,vulnerabilities,source,attachments,project_custom,bom_custom,license", 
+	help=f"Comma separated list (no spaces) of the reports to generate - {version_name_map.keys()} (default: all, except cryptography")
 parser.add_argument('--format', default='CSV', choices=["CSV"], help="Report format - only CSV available for now")
 parser.add_argument('-t', '--tries', default=4, type=int, help="How many times to retry downloading the report, i.e. wait for the report to be generated")
 parser.add_argument('-s', '--sleep_time', default=5, type=int, help="The amount of time to sleep in-between (re-)tries to download the report")
@@ -26,14 +41,6 @@ parser.add_argument('-s', '--sleep_time', default=5, type=int, help="The amount 
 args = parser.parse_args()
 
 hub = HubInstance()
-
-version_name_map = {
-	'version': 'VERSION',
-	'scans': 'CODE_LOCATIONS',
-	'components': 'COMPONENTS',
-	'vulnerabilities': 'SECURITY',
-	'source':'FILES'
-}
 
 class FailedReportDownload(Exception):
 	pass
@@ -50,7 +57,7 @@ def download_report(location, filename, retries=args.tries):
 			print("Successfully downloaded zip file to {} for report {}".format(filename, report_id))
 		else:
 			print("Failed to retrieve report {}".format(report_id))
-			print("Probably not ready yet, waiting 5 seconds then retrying...")
+			print(f"Probably not ready yet, waiting {args.sleep_time} seconds then retrying...")
 			time.sleep(args.sleep_time)
 			retries -= 1
 			download_report(location, filename, retries)

--- a/examples/generate_vuln_status_report.py
+++ b/examples/generate_vuln_status_report.py
@@ -57,7 +57,7 @@ def download_report(location, report_format, filename, retries=args.tries):
 						download_filename, report_id))
 			else:
 				print("Failed to retrieve report {}".format(report_id))
-				print("Probably not ready yet, waiting 5 seconds then retrying...")
+				print(f"Probably not ready yet, waiting {args.sleep_time} seconds then retrying...")
 				time.sleep(args.sleep_time)
 				retries -= 1
 				download_report(location, report_format, filename, retries)

--- a/examples/get_user_groups.py
+++ b/examples/get_user_groups.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 '''
 Created on Dec 4, 2018
 
@@ -12,9 +14,33 @@ from blackduck.HubRestApi import HubInstance
 
 hub = HubInstance()
 
-user_groups = hub.get_user_groups()
+user_groups = hub.get_user_groups(parameters = {"limit":"50000"})
 
 if 'totalCount' in user_groups and user_groups['totalCount'] > 0:
-	print(json.dumps(user_groups))
+    for group in user_groups['items']:
+        if group['createdFrom'] == 'INTERNAL' and not group['name'].endswith("DEPRECATED"):
+            #print(json.dumps(group))
+            print('---------------------------------------------------------')
+            print(f"== {group['name']}")
+            usergroup_url = group['_meta']['href'] + '/users?limit=10000'
+            response = hub.execute_get(usergroup_url)
+            users = response.json()
+            #print(users)
+            for user in users['items']:
+                if user['active'] and user['type'] == 'EXTERNAL':
+                    print(user['userName'])
+
+            print('--------')
+            projects_url = group['_meta']['href'] + '/projects?limit=10000'
+            response = hub.execute_get(projects_url)
+            projects = response.json()
+            #print(projects)
+            for project in projects['items']:
+                #project_url = project['project']
+                #project_id = project_url.rsplit('/', 1)[-1]
+                #print(project_id)
+                print(f"'{project['name']}',")
+            
+            
 else:
 	print("No user_groups found")

--- a/examples/user_list.csv
+++ b/examples/user_list.csv
@@ -1,4 +1,0 @@
-username,first,last,email
-flast9,first9,last9,flast9@snps.com
-flast7,first7,last7,flast7@snps.com
-flast8,first8,last8,flast8@snps.com

--- a/generate_reports.py
+++ b/generate_reports.py
@@ -45,7 +45,7 @@ parser.add_argument('--output', '-o', default='.', type=str, help='Output folder
 parser.add_argument('--format', '-m', default='JSON', choices=["CSV", "JSON"], help="Report format. 1 JSON file or multiple CSV files")
 parser.add_argument('--skip_cleanup', '-c', action="store_true", help='Do not remove reports generated on BlackDuck')
 parser.add_argument('--prefix', '-x', default='', type=str, help='String to add to the start of all project names')
-parser.add_argument('--sleep_time', '-t', default=5, type=int, help="Time in seconds to sleep between download attempts")
+parser.add_argument('--sleep_time', '-t', default=30, type=int, help="Time in seconds to sleep between download attempts")
 parser.add_argument('--log', action="store_true", help="Debug log output")
 
 args = parser.parse_args()

--- a/generate_reports.py
+++ b/generate_reports.py
@@ -497,13 +497,15 @@ else:
             
         with open(dest, "w") as f:
             first = True
-            if args.format == 'CSV':
-                f.write(pv.get_summary_header() + "\n")
-            else:
+            if args.format == 'JSON':
                 f.write("{\"Projects\":[")
                 
             for pv in all_pv:
                 if args.format == 'CSV':
+                    if first:
+                        first = False
+                        f.write(pv.get_summary_header() + "\n")
+                    
                     f.write(pv.get_summary() + "\n")
                 else:
                     if first:

--- a/generate_reports.py
+++ b/generate_reports.py
@@ -218,9 +218,9 @@ class ProjectVersion:
         csv = None
         for field in (self.SUMMARY_SHORT if args.summary == 'short' else self.SUMMARY_LONG):
             if csv:
-                csv = f"{csv},{str(self.summary.get(field, ''))}"
+                csv = f"{csv},{str(self.summary.get(field, 'n/a'))}"
             else:
-                csv = str(self.summary.get(field,''))
+                csv = str(self.summary.get(field,'n/a'))
                 
         return csv
 

--- a/generate_reports.py
+++ b/generate_reports.py
@@ -1,9 +1,14 @@
 #!/usr/bin/python3 
 
+import sys
 import argparse
 import json
+import datetime
 import time
 import logging
+
+import os.path
+from os import path
 
 from blackduck.HubRestApi import HubInstance
 
@@ -26,10 +31,15 @@ project name[;version][;destination]
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument('--project_name', '-p', type=str, help='Add a single project')
 group.add_argument('--project_file', '-f', type=argparse.FileType(), help='Add all projects listed in the file')
-
-parser.add_argument('--prefix', '-x', default='', type=str, help='String to add to the start of all project names')
 parser.add_argument('--version', '-v', default='master', type=str, help='Version to use if not specified in the file. Default: master')
-parser.add_argument('--sleep_time', '-s', default=5, type=int, help="Time in seconds to sleep between download attempts")
+
+parser.add_argument('--output', '-o', default='.', type=str, help='Output folder to download the reports into. Default: .')
+parser.add_argument('--summary', '-s', default=None, choices=["short", "full"], help='Create a summary csv file of the project(s). short option only lists the CRITICAL and HIGH issues.')
+parser.add_argument('--format', '-m', default='CSV', choices=["CSV", "JSON"], help="Report format. 1 JSON file or multiple CSV files")
+parser.add_argument('--no_reports', '-r', action="store_false", help='Do not call generate or fetch the reports. Implies -c, only relevant with --summary')
+parser.add_argument('--no_cleanup', '-c', action="store_false", help='Do not remove the report generated on BlackDuck')
+parser.add_argument('--prefix', '-x', default='', type=str, help='String to add to the start of all project names')
+parser.add_argument('--sleep_time', '-t', default=5, type=int, help="Time in seconds to sleep between download attempts")
 parser.add_argument('--log', '-l', action="store_true", help="Debug log output")
 
 args = parser.parse_args()
@@ -55,6 +65,14 @@ ch.setFormatter(formatter)
 log.addHandler(ch)
 
 
+if args.no_reports:
+    args.no_cleanup = True
+
+if not path.isdir(args.output):
+    log.fatal(f"Invalid output folder: {args.output}")
+    sys.exit()
+
+
 hub = HubInstance()
 
 class ProjectVersion:
@@ -69,6 +87,38 @@ class ProjectVersion:
         'PROJECT_VERSION_CUSTOM_FIELDS',
         'BOM_COMPONENT_CUSTOM_FIELDS',
         'LICENSE_TERM_FULFILLMENT',
+    ]
+    
+    SUMMARY_SHORT = [
+        'Project Name', 
+        'Version',
+        'Internal Version',
+        'Policy Violation',
+        'VULNERABILITY Risk CRITICAL',
+        'VULNERABILITY Risk HIGH',
+        'LICENSE Risk CRITICAL',
+        'LICENSE Risk HIGH',
+        'Last Scan',
+    ]
+    
+    SUMMARY_LONG = [
+        'Project Name', 
+        'Version',
+        'Internal Version',
+        'Policy Violation',
+        'VULNERABILITY Risk CRITICAL',
+        'VULNERABILITY Risk HIGH',
+        'VULNERABILITY Risk MEDIUM',
+        'VULNERABILITY Risk LOW',
+        'VULNERABILITY Risk OK',
+        'VULNERABILITY Risk UNKNOWN',
+        'LICENSE Risk CRITICAL',
+        'LICENSE Risk HIGH',
+        'LICENSE Risk MEDIUM',
+        'LICENSE Risk LOW',
+        'LICENSE Risk OK',
+        'LICENSE Risk UNKNOWN',
+        'Last Scan',
     ]
    
     def __init__(self, project_name, version_name, filename=None):
@@ -93,19 +143,98 @@ class ProjectVersion:
         else:
             self.error = f"Unknown project: {self.project_name}"
             
+        self.generate_summary()
+            
         if self.error:
             log.debug(self.error)
     
     def name(self):
-        return f"{self.project_name} - {self.version_name}"
+        return f"{self.project_name}-{self.version_name}"
             
+    def generate_summary(self):
+        if not args.summary:
+            return
+            
+        log.debug(f"Generating summary for: {self.name()}")
+        
+        self.summary = { 'Project Name': self.project_name, 'Version': self.version_name }
+        
+        log.debug(self.links.keys())
+        for key, link in self.links.items():
+            func_name = f"_parse_{key.replace('-','_')}"
+            func = getattr(self, func_name, None)
+            if func:
+                log.debug(f"Fetching {key}")
+                response = hub.execute_get(link)
+                if response and response.status_code == 200:
+                    data = response.json()
+                    func(data)
+                else:
+                    log.warning(f"Failed to get {key} for {self.name()}")
+       
+        
+    def _parse_policy_status(self, data):
+        log.debug("_parse_policy_status")
+        self.summary['Policy Violation'] = data['overallStatus']
+         
+    def _parse_custom_fields(self, data):
+        log.debug("_parse_custom_fields")
+
+        self.summary['Internal Version'] = None
+        for item in data['items']:
+            if item['label'] == 'Internal_Version' and len(item['values']) > 0:
+                self.summary['Internal Version'] = item['values'][0]
+        
+    def _parse_riskProfile(self, data):
+        log.debug("_parse_riskProfile")
+
+        for category in ('LICENSE', 'VULNERABILITY'):
+            for risk, value in data['categories'][category].items():
+                self.summary[f"{category} Risk {risk}"] = value       
+        
+    def _parse_codelocations(self, data):
+        log.debug("_parse_codelocations")
+        
+        self.summary['Last Scan'] = 'No scan'
+        for item in data['items']:      
+            udpatedAt = datetime.datetime.strptime(item['updatedAt'], '%Y-%m-%dT%H:%M:%S.%fZ')
+            if self.summary['Last Scan'] == 'No scan' or udpatedAt > self.summary['Last Scan']:
+                self.summary['Last Scan'] = udpatedAt
+
+        if self.summary['Last Scan'] != 'No scan':
+            self.summary['Last Scan'] = self.summary['Last Scan'].date().isoformat()
+
+    def get_summary_header(self):
+        if not args.summary:
+            return ""
+
+        fields = (self.SUMMARY_SHORT if args.summary == 'short' else self.SUMMARY_LONG)
+        return ",".join(fields)
+
+    def get_summary(self):
+        if not args.summary:
+            return ""
+
+        csv = None
+        for field in (self.SUMMARY_SHORT if args.summary == 'short' else self.SUMMARY_LONG):
+            if csv:
+                csv = f"{csv},{str(self.summary.get(field, ''))}"
+            else:
+                csv = str(self.summary.get(field,''))
+                
+        return csv
+
+
     def generate_report(self):
+        if not args.no_reports:
+            self.report_complete = True
+            return
+            
         if not self.version_object:
-            self.error = "No version object"
-            raise Exception(self.error)
+            return
         
         log.debug(f"Generating report for: {self.name()}")
-        response = hub.create_version_reports(self.version_object, self.reports, 'CSV')
+        response = hub.create_version_reports(self.version_object, self.reports, args.format)
         
         if response.status_code == 201:
             log.debug(f"Reports requested for: {self.name()}")
@@ -113,16 +242,17 @@ class ProjectVersion:
         else:
             self.error(f"Failed to request for: {self.name()}")
 
-    
+   
     def fetch_report(self):
-        if self.report_complete:
+        if not args.no_reports or self.report_complete:
             return
             
-        log.debug(f"Fetching report for: {self.name()}")
         if not self.links.get('downloadMeta'):
-            self.error = "No download link"
-            raise Exception(self.error)
-            
+            log.debug(f"No download link for: {self.name()}")
+            self.report_complete = True
+            return
+ 
+        log.debug(f"Fetching report for: {self.name()}") 
         if not self.filename:
             self.filename = f"{pv.name()}.zip"
         
@@ -133,32 +263,39 @@ class ProjectVersion:
             self.links['download-href'] = data['_meta']['links'][1]['href']
             response = hub.execute_get(self.links['download-href'])
             if response.status_code == 200:
-                with open(self.filename, "wb") as f:
+                dest = path.join(args.output, self.filename)
+                with open(dest, "wb") as f:
                     f.write(response.content)
                     
-                log.debug(f"Completed download to: {self.filename}")
+                log.debug(f"Completed download to: {dest}")
             else:
                 self.error = f"Unable to download report ({response.status_code})"
             
             self.report_complete = True
                
         else:
-            log.debug(f"Waiting... : {self.name()}")
+            log.debug(f"Report not ready for: {self.name()}")
             
     def clean_up(self):
         if self.error:
-            log.warning(f"'{self.name()}' generated error: {self.error}")
+            log.critical(f"'{self.name()}' generated error: {self.error}")
             
-        if self.links.get('download-href'):
+        if args.no_cleanup:
+            log.debug(f"Skipping clean up of online report for: {self.name()}")
+        elif self.links.get('download-href'):
             log.debug(f"Cleaning up online report for: {self.name()}")
             hub.execute_delete(self.links.get('download-href'))
             
         self.version_object = None
             
 
-print('Generating report(s)...')
+
+# ------------------------------------------------------------------------------  
+# Main code
 
 if args.project_name:
+    print('Generating report...')
+    pv = None
     try:
         pv = ProjectVersion(f"{args.prefix}{args.project_name}", args.version)
         pv.generate_report()
@@ -168,10 +305,19 @@ if args.project_name:
             pv.fetch_report()
 
     finally:
-        pv.clean_up()
+        if pv:
+            pv.clean_up()
         
     print(f"{pv.name()} download complete")
+    if args.summary:
+        print("Writing summary")
+        dest = path.join(args.output, 'summary.csv')
+        with open(dest, "w") as f:
+            f.write(pv.get_summary_header() + "\n")
+            f.write(pv.get_summary() + "\n")
+        
 else:
+    print('Generating reports...')
     all_pv = []
     f = args.project_file
     log.debug(f"Parsing input file: {f.name}")
@@ -199,20 +345,44 @@ else:
             destination = None
 
         log.debug(f">>> {project_name} - {version_name} => {destination}")
-        pv = ProjectVersion(project_name, version_name, destination)
-        pv.generate_report()
-        all_pv.append(pv)
-
+        pv = None
+        try:
+            pv = ProjectVersion(project_name, version_name, destination)
+            pv.generate_report()
+            all_pv.append(pv)
+        except:
+            log.critical(f"Unable to generate report for: {project_name} - {version_name}")
+        finally:
+            if pv:
+                pv.clean_up()
+        
     while True:
         all_complete = True
+        count = 0
         for pv in all_pv:
             pv.fetch_report()
-            all_complete = all_complete and pv.report_complete
-            
-        time.sleep(args.sleep_time)
-        
+            if pv.report_complete:
+                count += 1
+            else:
+                all_complete = False
+       
         if all_complete:
             break
+        else:
+            print(f"{count}/{len(all_pv)} reports downloaded")
+            time.sleep(args.sleep_time)
         
     for pv in all_pv:
         pv.clean_up()
+
+    print(f"All downloads complete")
+    
+    if args.summary:
+        print("Writing summary")
+        dest = path.join(args.output, 'summary.csv')
+        with open(dest, "w") as f:
+            f.write(pv.get_summary_header() + "\n")
+            for pv in all_pv:
+                f.write(pv.get_summary() + "\n")
+
+   

--- a/generate_reports.py
+++ b/generate_reports.py
@@ -155,16 +155,15 @@ class ProjectVersion:
         if not args.summary:
             return
             
-        log.debug(f"Generating summary for: {self.name()}")
+        print(f"Generating summary for: {self.name()}")
         
         self.summary = { 'Project Name': self.project_name, 'Version': self.version_name }
         
-        log.debug(self.links.keys())
+        #log.debug(self.links.keys())
         for key, link in self.links.items():
             func_name = f"_parse_{key.replace('-','_')}"
             func = getattr(self, func_name, None)
             if func:
-                log.debug(f"Fetching {key}")
                 response = hub.execute_get(link)
                 if response and response.status_code == 200:
                     data = response.json()
@@ -233,7 +232,7 @@ class ProjectVersion:
         if not self.version_object:
             return
         
-        log.debug(f"Generating report for: {self.name()}")
+        print(f"Generating report for: {self.name()}")
         response = hub.create_version_reports(self.version_object, self.reports, args.format)
         
         if response.status_code == 201:
@@ -267,7 +266,7 @@ class ProjectVersion:
                 with open(dest, "wb") as f:
                     f.write(response.content)
                     
-                log.debug(f"Completed download to: {dest}")
+                print(f"Completed download to: {dest}")
             else:
                 self.error = f"Unable to download report ({response.status_code})"
             

--- a/generate_reports.py
+++ b/generate_reports.py
@@ -1,0 +1,218 @@
+#!/usr/bin/python3 
+
+import argparse
+import json
+import time
+import logging
+
+from blackduck.HubRestApi import HubInstance
+
+const_project_roles = [ "Project Code Scanner", "BOM Manager", "Project Viewer", "Project Manager", "Security Manager", "Policy Violation Reviewer"]
+
+# ------------------------------------------------------------------------------
+# Parse command line
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description='Generates and downloads reports for project(s) on blackduck.com',
+    epilog='''\
+Note: When using the --project_file option the file format per line MUST be:
+
+# Lines starting # are ignored, so are empty lines
+project name[;version][;destination]
+'''
+)
+
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--project_name', '-p', type=str, help='Add a single project')
+group.add_argument('--project_file', '-f', type=argparse.FileType(), help='Add all projects listed in the file')
+
+parser.add_argument('--prefix', '-x', default='', type=str, help='String to add to the start of all project names')
+parser.add_argument('--version', '-v', default='master', type=str, help='Version to use if not specified in the file. Default: master')
+parser.add_argument('--sleep_time', '-s', default=5, type=int, help="Time in seconds to sleep between download attempts")
+parser.add_argument('--log', '-l', action="store_true", help="Debug log output")
+
+args = parser.parse_args()
+# create logger
+log = logging.getLogger('debug')
+if args.log:
+    log.setLevel(logging.DEBUG)
+else:
+    log.setLevel(logging.CRITICAL)
+
+# create console handler and set level to debug
+ch = logging.StreamHandler()
+if args.log:
+    ch.setLevel(logging.DEBUG)
+else:
+    ch.setLevel(logging.CRITICAL)
+    
+# create formatter
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+# add formatter to ch
+ch.setFormatter(formatter)
+# add ch to logger
+log.addHandler(ch)
+
+
+hub = HubInstance()
+
+class ProjectVersion:
+    reports = [
+        'VERSION',
+        'CODE_LOCATIONS',
+        'COMPONENTS',
+        'SECURITY',
+        'FILES',
+        'ATTACHMENTS',
+        # 'CRYPTO_ALGORITHMS',
+        'PROJECT_VERSION_CUSTOM_FIELDS',
+        'BOM_COMPONENT_CUSTOM_FIELDS',
+        'LICENSE_TERM_FULFILLMENT',
+    ]
+   
+    def __init__(self, project_name, version_name, filename=None):
+        log.debug(f"Initialising ProjectVersion: {project_name} - {version_name}")
+        self.project_name = project_name 
+        self.version_name = version_name
+        self.filename = filename
+        
+        self.error = None
+        self.report_complete = False
+        self.links = {}
+        
+        project_object = hub.get_project_by_name(self.project_name)
+        if project_object:
+            self.version_object = hub.get_version_by_name(project_object, self.version_name)
+            if self.version_object:
+                links = self.version_object['_meta']['links']
+                for link in links:
+                    self.links[link['rel']] = link['href']
+            else:
+                self.error = f"Project '{self.project_name}' has no version: {self.version_name}"
+        else:
+            self.error = f"Unknown project: {self.project_name}"
+            
+        if self.error:
+            log.debug(self.error)
+    
+    def name(self):
+        return f"{self.project_name} - {self.version_name}"
+            
+    def generate_report(self):
+        if not self.version_object:
+            self.error = "No version object"
+            raise Exception(self.error)
+        
+        log.debug(f"Generating report for: {self.name()}")
+        response = hub.create_version_reports(self.version_object, self.reports, 'CSV')
+        
+        if response.status_code == 201:
+            log.debug(f"Reports requested for: {self.name()}")
+            self.links['downloadMeta'] = response.headers['Location']
+        else:
+            self.error(f"Failed to request for: {self.name()}")
+
+    
+    def fetch_report(self):
+        if self.report_complete:
+            return
+            
+        log.debug(f"Fetching report for: {self.name()}")
+        if not self.links.get('downloadMeta'):
+            self.error = "No download link"
+            raise Exception(self.error)
+            
+        if not self.filename:
+            self.filename = f"{pv.name()}.zip"
+        
+        response = hub.execute_get(self.links['downloadMeta'])
+        data = response.json() 
+        
+        if response.status_code == 200 and data['status'] == 'COMPLETED':
+            self.links['download-href'] = data['_meta']['links'][1]['href']
+            response = hub.execute_get(self.links['download-href'])
+            if response.status_code == 200:
+                with open(self.filename, "wb") as f:
+                    f.write(response.content)
+                    
+                log.debug(f"Completed download to: {self.filename}")
+            else:
+                self.error = f"Unable to download report ({response.status_code})"
+            
+            self.report_complete = True
+               
+        else:
+            log.debug(f"Waiting... : {self.name()}")
+            
+    def clean_up(self):
+        if self.error:
+            log.warning(f"'{self.name()}' generated error: {self.error}")
+            
+        if self.links.get('download-href'):
+            log.debug(f"Cleaning up online report for: {self.name()}")
+            hub.execute_delete(self.links.get('download-href'))
+            
+        self.version_object = None
+            
+
+print('Generating report(s)...')
+
+if args.project_name:
+    try:
+        pv = ProjectVersion(f"{args.prefix}{args.project_name}", args.version)
+        pv.generate_report()
+        log.info(pv.links.get('downloadMeta'))
+        while not pv.report_complete:
+            time.sleep(args.sleep_time)
+            pv.fetch_report()
+
+    finally:
+        pv.clean_up()
+        
+    print(f"{pv.name()} download complete")
+else:
+    all_pv = []
+    f = args.project_file
+    log.debug(f"Parsing input file: {f.name}")
+    for line in f.readlines():
+        line = line.strip()
+        if not line or line[0] == "#":
+            continue
+            
+        log.debug(f">> {line}")
+            
+        index=0
+        params = line.split(";")
+        project_name = f"{args.prefix}{params[0]}"
+        
+        version_name = None
+        if len(params) > 1:
+            version_name = params[1]
+        
+        if not version_name:
+            version_name = args.version
+            
+        if len(params) > 2:
+            destination = params[2]
+        else:
+            destination = None
+
+        log.debug(f">>> {project_name} - {version_name} => {destination}")
+        pv = ProjectVersion(project_name, version_name, destination)
+        pv.generate_report()
+        all_pv.append(pv)
+
+    while True:
+        all_complete = True
+        for pv in all_pv:
+            pv.fetch_report()
+            all_complete = all_complete and pv.report_complete
+            
+        time.sleep(args.sleep_time)
+        
+        if all_complete:
+            break
+        
+    for pv in all_pv:
+        pv.clean_up()

--- a/generate_reports.py
+++ b/generate_reports.py
@@ -37,7 +37,7 @@ group.add_argument('--project_file', '-f', type=argparse.FileType(), help='Add a
 parser.add_argument('--version', '-v', default='master', type=str, help='Version to use if not specified in the file. Default: master')
 
 group_reports = parser.add_argument_group('reports', description='Select 1 or more to generate')
-group_reports.add_argument('--summary', '-s', default=None, choices=["short", "full"], help='Create a summary report json file of the project(s). short option only lists the CRITICAL and HIGH issues.')
+group_reports.add_argument('--summary', '-s', default=None, choices=["short", "full"], help='Create a summary report json (default) or csv file of the project(s). short option only lists the CRITICAL and HIGH issues.')
 group_reports.add_argument('--detailed', '-d', action="store_true", help='Generate and fetch the detailed reports.')
 group_reports.add_argument('--licence', '-l', action="store_true", help='Generate and fetch the licence report (aka Notices file).')
 
@@ -397,7 +397,11 @@ if args.project_name:
             
         if args.summary:
             print("Writing summary")
-            dest = path.join(args.output, 'summary.csv')
+            if args.format == 'CSV':
+                dest = path.join(args.output, 'summary.csv')
+            else:
+                dest = path.join(args.output, 'summary.json')
+            
             with open(dest, "w") as f:
                 f.write(pv.get_summary_header() + "\n")
                 f.write(pv.get_summary() + "\n")
@@ -486,7 +490,11 @@ else:
     
     if args.summary:
         print("Writing summary")
-        dest = path.join(args.output, 'summary.csv')
+        if args.format == 'CSV':
+            dest = path.join(args.output, 'summary.csv')
+        else:
+            dest = path.join(args.output, 'summary.json')
+            
         with open(dest, "w") as f:
             first = True
             if args.format == 'CSV':

--- a/rename_user_groups.py
+++ b/rename_user_groups.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3 
+
+import argparse
+import json
+
+from blackduck.HubRestApi import HubInstance
+
+# ------------------------------------------------------------------------------
+# Parse command line
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description='Rename user groups on blackduck.com from the Azure UUID to their name',
+)
+
+
+parser.add_argument('--file', '-f', type=str, required=True, help='Export file from Azure with the UUID to group name mapping')
+
+args = parser.parse_args()
+
+# ------------------------------------------------------------------------------
+# Functions
+
+azure_map = {}
+   
+def read_file(filename):
+    with open(filename) as file:
+        line = file.readline()       
+        while line:
+            parts = line.split(',')
+            if parts[2] == "Security":
+                azure_map[parts[0]] = parts[1]
+            line = file.readline()  
+    
+# ------------------------------------------------------------------------------  
+# Main code
+
+read_file(args.file)
+#print(azure_map)
+
+hub = HubInstance()
+user_groups = hub.get_user_groups(parameters = {"limit":"50000"})
+for group in user_groups['items']:
+    if group.get('externalName') and group['name'] == group['externalName']:
+        new_name = azure_map.get(group['name'])
+        usergroup_url = group['_meta']['href']
+        if new_name:
+            #print(group)
+            print(f"{group['name']} => {new_name} => {usergroup_url}" )
+            json = {
+                "name": new_name,
+                "active": True,
+                "createdFrom": "SAML",
+                "default": False,
+                "externalName": group['externalName']
+            }
+            
+            #print(json)
+            response = hub.execute_put(usergroup_url, json)
+            #print(response)
+        else:
+            print(f"No name found for {group['name']} => {usergroup_url}" )
+

--- a/rename_user_groups.py
+++ b/rename_user_groups.py
@@ -41,7 +41,7 @@ read_file(args.file)
 hub = HubInstance()
 user_groups = hub.get_user_groups(parameters = {"limit":"50000"})
 for group in user_groups['items']:
-    if group.get('externalName') and group['name'] == group['externalName']:
+    if group['createdFrom'] == 'SAML' and group.get('externalName') and group['name'] == group['externalName']:
         new_name = azure_map.get(group['name'])
         usergroup_url = group['_meta']['href']
         if new_name:

--- a/update_project.py
+++ b/update_project.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python3 
+
+import argparse
+import json
+
+from blackduck.HubRestApi import HubInstance
+
+# ------------------------------------------------------------------------------
+# Parse command line
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description='Update project(s) on blackduck.com',
+    epilog='''\
+Note: When using the --project_file option the file format per line MUST be:
+
+# Lines starting # are ignored, so are empty lines
+project name[;group1[,group2,...,groupN]][;description][;version]
+'''
+)
+
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--project_name', '-p', type=str, help='Add a single project')
+group.add_argument('--project_file', '-f', type=argparse.FileType(), help='Add all projects listed in the file')
+
+parser.add_argument('--group', '-g', type=str, help='Default group to use (normally SAML). Optionally overridden when using a file.' )
+
+parser.add_argument('--prefix', default='', type=str, help='String to add to the start of the project name')
+parser.add_argument('--version', '-v', default='master', type=str, help='Version to use if not specified in the file')
+parser.add_argument('--description', '-d', default='', type=str, help='Default description for all projects')
+
+args = parser.parse_args()
+
+
+# ------------------------------------------------------------------------------
+# Functions
+   
+def get_user_groups(names=[]):
+    #print(f"Getting groups: {names}")
+    groups = []
+    for name in names:
+        if name == args.group:
+            group = default_group
+        else:
+            group = hub.get_user_group_by_name(name)
+            if not group:
+                print(f"Unable to find group: {name}")
+                return None
+        
+        groups.append(group['name'])
+    return groups
+
+
+def create_project_with_groups(name=str, version=str, description=str, groups=[]):
+    #print(f"create_project_with_groups({name}, {version}, {description}, {groups})")
+    if not groups:
+        groups = [args.group]
+    else:
+        groups = get_user_groups(groups)
+        if groups is None:
+            return False, "Failed to find group"
+
+    if args.prefix:
+        name = f"{args.prefix} {name}"
+        
+    #print(f"Creating project: {name}")        
+    response = hub.create_project(name, version, parameters = {
+		'description': description
+	})
+    
+    if response and response.status_code == 201:
+        # Attach the user group(s) to the new project
+        for group in groups:
+            response = hub.assign_user_group_to_project(name, group, [])
+            if not response or response.status_code != 201:
+                print(f"WARNING: Failed to assign group {group} to project {name}")
+        
+        return True, f"Created project: {name}"
+        
+    if response.status_code == 412:
+        return False, f"Project already exists: {name}"
+        
+    return False, f"Failed to create project: {name} : {response}"
+        
+        
+# ------------------------------------------------------------------------------  
+# Main code
+
+hub = HubInstance()
+
+project = hub.get_project_by_name(args.project_name)
+print(f"{project}")
+
+#roles = hub.get_project_roles()
+#print(f"{roles}")
+
+default_group = hub.get_user_group_by_name(args.group)
+print(f"{default_group}")    
+
+if project:
+    project_updated = project
+
+    #project_updated['name'] = "mlester-test-cli"
+    #project_updated['description'] = "Hello world"
+    #project_updated['owner'] = "mlester"
+    #hub.update_project_settings(project, project_updated)
+    
+raise SystemExit(f"Done")
+
+
+default_group = hub.get_user_group_by_name(args.group)
+if default_group is None:
+    raise SystemExit(f"Unable to find default group: ${args.group}")
+#print(f"default_group: {default_group}")    
+
+if args.project_name is not None:
+    print(f"Adding the single project: {args.project_name}")
+    status, response = create_project_with_groups(args.project_name, args.version, args.description)
+    if status == False:
+        raise SystemExit(f"FATAL: {response}")
+    else:
+        print(response)
+else:
+    f = args.project_file
+    print(f"Parsing the projects file: {f.name}")
+    for line in f.readlines():
+        line = line.strip()
+        if not line or line[0] == "#":
+            continue
+        
+        #print(f">> {line}")
+        params = line.split(";")
+        options = {'project_name':'', 'groups': [args.group], 'description': args.description, 'version':args.version}
+        option_names = list(options)
+        index=0
+        for param in params:
+            if index >= len(option_names):
+                break
+            
+            if option_names[index] == "groups":
+                param = param.split(",")
+                if len(param) == 1 and not param[0]:
+                    param = None
+            
+            if param:
+                options[option_names[index]] = param
+                
+            index += 1
+
+        #print(options)
+        status, response = create_project_with_groups(options['project_name'], options['version'], options['description'], options['groups'])
+        if status == False:
+            print(f"ERROR: {response}")
+        else:
+            print(response)


### PR DESCRIPTION
Add optional "use_session" parameter to the .restconfig.json file - true means use a Python requests session so that the HTTP connection is kept open between REST requests made via the HubInstance; false means current behaviour, where a new HTTP connection is used for each REST request (together with DNS lookups, if not cached by the client's OS, and TCP/TLS handshaking).  For a series of REST requests/responses a persistent connection can halve the overall time taken.

By default, if the use_session parameter is not present, a persistent HTTP connection will not be used - reflecting existing behaviour.

Also make a small fix to the URL used in get_version_by_id().