### PR TITLE
Reimplemented

### DIFF
--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -1259,42 +1259,42 @@ class HubInstance(object):
     #
     # Add project version as a component to another project
     # 
-    # WARNING: Uses internal API
-    ###
-    
-    # TODO: Refactor this code to use the (newly released, v2019.4.0) public endpoint for adding sub-projects (POST /api/projects/{projectId}/versions/{projectVersionId}/components)
-    #       ref: https://jira.dc1.lan/browse/HUB-16972
+    # 
     
     def add_version_as_component(self, main_project_release, sub_project_release):
         headers = self.get_headers()
         main_data = main_project_release['_meta']['href'].split('/')
         sub_data = sub_project_release['_meta']['href'].split('/')
-        url = self.get_apibase() + "/v1/releases/" + main_data[7] + "/component-bom-entries"
-        logger.debug(url)
+        main_project_release_links = main_project_release['_meta']['links']
+        main_project_release_component_links = [x for x in main_project_release_links if x['rel'] == 'components']
+        main_project_release_component_link = main_project_release_component_links[0]['href']
+        logger.debug(main_project_release_component_link)
+        sub_project_release_as_custom_component_url = self.get_apibase() + "/components/" + sub_data[5] + "/versions/" + sub_data[7]
+        logger.debug(sub_project_release_as_custom_component_url)
         payload = {}
-        payload['producerProject'] = {}
-        payload['producerProject']['id'] = sub_data[5]
-        payload['producerRelease'] = {} 
-        payload['producerRelease']['id'] = sub_data[7]
+        payload['component'] = sub_project_release_as_custom_component_url
         logger.debug(json.dumps(payload))
-        response = requests.post(url, headers=headers, verify = not self.config['insecure'], json=payload)
-        jsondata = response.json()
-        return jsondata
+        response = requests.post(main_project_release_component_link, headers=headers, verify = not self.config['insecure'], json=payload)
+        logger.debug(response)
+        return response
+    
+    ###
+    #
+    # Remove a project version as a component from another project
+    # 
+    # 
 
     def remove_version_as_component(self, main_project_release, sub_project_release):
         headers = self.get_headers()
         main_data = main_project_release['_meta']['href'].split('/')
         sub_data = sub_project_release['_meta']['href'].split('/')
-        url = self.get_apibase() + "/v1/releases/" + main_data[7] + "/component-bom-entries"
-        logger.debug(url)
-        payload = []
-        entity = {}
-        entity['entityKey'] = {}
-        entity['entityKey']['entityId'] = sub_data[7]
-        entity['entityKey']['entityType'] = 'RL'
-        payload.append(entity)
-        logger.debug(json.dumps(payload))
-        response = requests.delete(url, headers=headers, verify = not self.config['insecure'], json=payload)
+        main_project_release_links = main_project_release['_meta']['links']
+        main_project_release_component_links = [x for x in main_project_release_links if x['rel'] == 'components']
+        main_project_release_component_link = main_project_release_component_links[0]['href']
+        logger.debug(main_project_release_component_link)
+        subcomponent_url = main_project_release_component_link + "/" + sub_data[5] + "/versions/" + sub_data[7]
+        logger.debug(subcomponent_url)
+        response = requests.delete(subcomponent_url, headers=headers, verify = not self.config['insecure'])
         return response
 
     ###


### PR DESCRIPTION
    add_version_as_component
    remove_version_as_component
using public API.
Removed old functions that were using the old API calls since new API is
supported since 2019.4.0