### PR TITLE
Gms/add nodetails vulnerablity info

### DIFF
--- a/examples/get_bom_component_vulnerability_info.py
+++ b/examples/get_bom_component_vulnerability_info.py
@@ -44,8 +44,12 @@ parser.add_argument("-n", "--newer_than",
 parser.add_argument("-s", "--save_dt", 
 	action='store_true', 
 	help="If set, the date/time will be saved to a file named '.last_run' in the current directory which can be used later with the -n option to see vulnerabilities published since the last run.")
-parser.add_argument("-l", "--limit", default=9999, help="Set limit on number of vulnerabilitties to retrieve (default 9999)")
-parser.add_argument("-nd", type=bool, default=False, help="Disables retrieving details for each vulnerability to reduce execution time")
+parser.add_argument("-l", "--limit",
+    default=9999,
+    help="Set limit on number of vulnerabilitties to retrieve (default 9999)")
+parser.add_argument("-nd", "--nodetails",
+    action='store_true',
+    help="If set, disables retrieving details for each vulnerability to reduce execution time")
 args = parser.parse_args()
 
 
@@ -69,7 +73,7 @@ project = hub.get_project_by_name(args.project_name)
 version = hub.get_version_by_name(project, args.version)
 version_id = object_id(version)
 
-vulnerablity_limit = "limit?={}".format(args.limit)
+vulnerablity_limit = "?limit={}".format(args.limit)
 
 vulnerable_components_url = hub.get_link(version, "vulnerable-components") + vulnerablity_limit
 custom_headers = {'Accept':'application/vnd.blackducksoftware.bill-of-materials-6+json'}
@@ -113,7 +117,7 @@ if args.nodetails==False:
         elif source == "NVD":
             cve_records.add(vuln_name)
         else:
-            logging.warning(f"source {source} was not recognized")
+            logging.warning("source {source} was not recognized")
 
 if vulnerable_bom_components:
     vulnerable_bom_components = sorted(

--- a/examples/get_bom_component_vulnerability_info.py
+++ b/examples/get_bom_component_vulnerability_info.py
@@ -117,7 +117,7 @@ if args.nodetails==False:
         elif source == "NVD":
             cve_records.add(vuln_name)
         else:
-            logging.warning("source {source} was not recognized")
+            logging.warning(f"source {source} was not recognized")
 
 if vulnerable_bom_components:
     vulnerable_bom_components = sorted(

--- a/examples/get_bom_component_vulnerability_info.py
+++ b/examples/get_bom_component_vulnerability_info.py
@@ -44,7 +44,10 @@ parser.add_argument("-n", "--newer_than",
 parser.add_argument("-s", "--save_dt", 
 	action='store_true', 
 	help="If set, the date/time will be saved to a file named '.last_run' in the current directory which can be used later with the -n option to see vulnerabilities published since the last run.")
+parser.add_argument("-l", "--limit", default=9999, help="Set limit on number of vulnerabilitties to retrieve (default 9999)")
+parser.add_argument("-nd", type=bool, default=False, help="Disables retrieving details for each vulnerability to reduce execution time")
 args = parser.parse_args()
+
 
 if args.newer_than:
 	newer_than = timestring.Date(args.newer_than).date
@@ -66,7 +69,9 @@ project = hub.get_project_by_name(args.project_name)
 version = hub.get_version_by_name(project, args.version)
 version_id = object_id(version)
 
-vulnerable_components_url = hub.get_link(version, "vulnerable-components") + "?limit=9999"
+vulnerablity_limit = "limit?={}".format(args.limit)
+
+vulnerable_components_url = hub.get_link(version, "vulnerable-components") + vulnerablity_limit
 custom_headers = {'Accept':'application/vnd.blackducksoftware.bill-of-materials-6+json'}
 response = hub.execute_get(vulnerable_components_url, custom_headers=custom_headers)
 vulnerable_bom_components = response.json().get('items', [])
@@ -74,39 +79,41 @@ vulnerable_bom_components = response.json().get('items', [])
 bdsa_records = set()
 cve_records = set()
 
-for i, vuln in enumerate(vulnerable_bom_components):
-    source = vuln['vulnerabilityWithRemediation']['source']
-    vuln_name = vuln['vulnerabilityWithRemediation']['vulnerabilityName']
 
-    # Retrieve additional details about the vulnerability
-    #
+if args.nodetails==False:
+    for i, vuln in enumerate(vulnerable_bom_components):
+        source = vuln['vulnerabilityWithRemediation']['source']
+        vuln_name = vuln['vulnerabilityWithRemediation']['vulnerabilityName']
 
-    update_guidance_url = vuln['componentVersion'] + "/upgrade-guidance"
-    update_guidance_results = hub.execute_get(update_guidance_url).json()
-    vuln['update_guidance'] = update_guidance_results
+        # Retrieve additional details about the vulnerability
+        #
 
-    logging.debug("Retrieving additional details regarding vuln {}, i={}".format(vuln_name, i))
-    vuln_url = hub.get_apibase() + "/vulnerabilities/{}".format(vuln_name)
-    vuln_details_response = hub.execute_get(vuln_url, custom_headers={'Accept': 'application/json'})
-    vuln_details = vuln_details_response.json()
+        update_guidance_url = vuln['componentVersion'] + "/upgrade-guidance"
+        update_guidance_results = hub.execute_get(update_guidance_url).json()
+        vuln['update_guidance'] = update_guidance_results
 
-    vuln['additional_vuln_info'] = vuln_details
+        logging.debug("Retrieving additional details regarding vuln {}, i={}".format(vuln_name, i))
+        vuln_url = hub.get_apibase() + "/vulnerabilities/{}".format(vuln_name)
+        vuln_details_response = hub.execute_get(vuln_url, custom_headers={'Accept': 'application/json'})
+        vuln_details = vuln_details_response.json()
 
-    if source == 'BDSA':
-        bdsa_records.add(vuln_name)
+        vuln['additional_vuln_info'] = vuln_details
 
-        # get related vulnerability info, i.e. CVE
-        # note: not all BDSA records will have a corresponding CVE record
-        cve_url = hub.get_link(vuln_details, "related-vulnerability")
-        if cve_url:
-            cve_details_response = hub.execute_get(cve_url, custom_headers={'Accept': 'application/json'})
-            cve_details = cve_details_response.json()
-            vuln['related_vulnerability'] = cve_details
-            cve_records.add(cve_details['name'])
-    elif source == "NVD":
-        cve_records.add(vuln_name)
-    else:
-        logging.warning(f"source {source} was not recognized")
+        if source == 'BDSA':
+            bdsa_records.add(vuln_name)
+
+            # get related vulnerability info, i.e. CVE
+            # note: not all BDSA records will have a corresponding CVE record
+            cve_url = hub.get_link(vuln_details, "related-vulnerability")
+            if cve_url:
+                cve_details_response = hub.execute_get(cve_url, custom_headers={'Accept': 'application/json'})
+                cve_details = cve_details_response.json()
+                vuln['related_vulnerability'] = cve_details
+                cve_records.add(cve_details['name'])
+        elif source == "NVD":
+            cve_records.add(vuln_name)
+        else:
+            logging.warning(f"source {source} was not recognized")
 
 if vulnerable_bom_components:
     vulnerable_bom_components = sorted(
@@ -142,13 +149,18 @@ counts = {
     'by_remediation_status': remediation_counts
 }
 
-
-everything = {
-    'counts': counts,
-    'vulnerabilities': vulnerable_bom_components,
-    'bdsa_records': list(bdsa_records),
-    'cve_records': list(cve_records),
-}
+if args.nodetails==False:
+    everything = {
+        'counts': counts,
+        'vulnerabilities': vulnerable_bom_components,
+        'bdsa_records': list(bdsa_records),
+        'cve_records': list(cve_records),
+    }
+else:
+    everything = {
+        'counts': counts,
+        'vulnerabilities': vulnerable_bom_components,
+    }
 
 print(json.dumps(everything))
 


### PR DESCRIPTION
Added two options to get_bom_component_vulnerability_info.py:
   -nd, --nodetail: suppress retrieving additional vulnerability details to reduce execution time
  -l, --limit: allow user to set the limit for vulnerability details retrieved.  Default is 9999

@gsnyder2007 @mkumykov 