### PR TITLE
Matching on "enclosure" is returning an empty list when downloading bdio files.

### DIFF
--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -1331,7 +1331,7 @@ class HubInstance(object):
         
         for item in codelocations['items']:
             links = item['_meta']['links']
-            matches = [x for x in links if x['rel'] == 'enclosure']
+            matches = [x for x in links if x['rel'] == 'enclosure' or x['rel'] == 'scan-data']
             for m in matches:
                 url = m['href']
                 filename = url.split('/')[6]


### PR DESCRIPTION
blackduck.HubRestApi.HubInstance.download_project_scans is returning an empty list in 2020.8 and 2020.10. 
Adding "scan-data" to the match filter seems to fix the issue.  

Matching on "scan-data" in items['_meta']['links]['rel] because "enclosure" is returning an empty list when downloading bdio files.

OSISoft is using this endpoint in an ADO job and their wish is to not have to manually update the repo after it is cloned.  
