### PR TITLE
Update notices report generation to check for 412 unfinished report c…

### DIFF
--- a/examples/generate_notices_report_for_project_version.py
+++ b/examples/generate_notices_report_for_project_version.py
@@ -29,64 +29,67 @@ hub = HubInstance()
 logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
 
 class FailedReportDownload(Exception):
-	pass
+    pass
+
+DOWNLOAD_ERROR_CODES = ['{report.main.read.unfinished.report}', '{report.main.download.unfinished.report}']
 
 def download_report(location, file_name_base, retries=10):
-	report_id = location.split("/")[-1]
+    report_id = location.split("/")[-1]
 
-	if retries:
-		logging.debug("Retrieving generated report from {}".format(location))
-		# response = hub.download_report(report_id)
-		response, report_format = hub.download_notification_report(location)
-		if response.status_code == 200:
-			if report_format == "TEXT":
-				filename = file_name_base + ".zip"
-				with open(filename, "wb") as f:
-					f.write(response.content)
-			else:
-				# JSON format
-				filename = file_name_base + ".json"
-				with open(filename, "w") as f:
-					json.dump(response.json(), f, indent=3)
-			logging.info("Successfully downloaded json file to {} for report {}".format(
-					filename, report_id))
-		elif response.status_code == 412 and response.json()['errorCode'] == '{report.main.read.unfinished.report.contents}':
-			# failed to download, and report generation still in progress, wait and try again infinitely
-			# TODO: is it possible for things to get stuck in this forever?
-			logging.warning(f"Failed to retrieve report {report_id} for reason {response.json()['errorCode']}.  Waiting 5 seconds then trying infinitely")
-			time.sleep(5)
-			download_report(location, file_name_base, retries)
-		else:
-			logging.warning("Failed to retrieve report {}".format(report_id))
-			logging.warning("Probably not ready yet, waiting 5 seconds then retrying (remaining retries={}".format(retries))
-			time.sleep(5)
-			retries -= 1
-			download_report(location, file_name_base, retries)
-	else:
-		raise FailedReportDownload("Failed to retrieve report {} after multiple retries".format(report_id))
+    if retries:
+        logging.debug("Retrieving generated report from {}".format(location))
+        # response = hub.download_report(report_id)
+        response, report_format = hub.download_notification_report(location)
+
+        if response.status_code == 200:
+            if report_format == "TEXT":
+                filename = file_name_base + ".zip"
+                with open(filename, "wb") as f:
+                    f.write(response.content)
+            else:
+                # JSON format
+                filename = file_name_base + ".json"
+                with open(filename, "w") as f:
+                    json.dump(response.json(), f, indent=3)
+            logging.info("Successfully downloaded json file to {} for report {}".format(
+                    filename, report_id))
+        elif response.status_code == 412 and response.json()['errorCode'] in DOWNLOAD_ERROR_CODES:
+            # failed to download, and report generation still in progress, wait and try again infinitely
+            # TODO: is it possible for things to get stuck in this forever?
+            logging.warning(f"Failed to retrieve report {report_id} for reason {response.json()['errorCode']}.  Waiting 5 seconds then trying infinitely")
+            time.sleep(5)
+            download_report(location, file_name_base, retries)
+        else:
+            logging.warning(f"Failed to retrieve report, status code {response.status_code}")
+            logging.warning("Probably not ready yet, waiting 5 seconds then retrying (remaining retries={}".format(retries))
+            time.sleep(5)
+            retries -= 1
+            download_report(location, file_name_base, retries)
+    else:
+        raise FailedReportDownload("Failed to retrieve report {} after multiple retries".format(report_id))
 
 project = hub.get_project_by_name(args.project_name)
 
 if project:
-	version = hub.get_version_by_name(project, args.version_name)
+    version = hub.get_version_by_name(project, args.version_name)
 
-	response = hub.create_version_notices_report(version, args.report_format, include_copyright_info=args.include_copyright_info)
+    response = hub.create_version_notices_report(version, args.report_format, include_copyright_info=args.include_copyright_info)
 
-	if response.status_code == 201:
-		logging.info("Successfully created notices report in {} format for project {} and version {}".format(
-			args.report_format, args.project_name, args.version_name))
-		location = response.headers['Location']
-		download_report(location, args.file_name_base)
+    if response.status_code == 201:
+        logging.info("Successfully created notices report in {} format for project {} and version {}".format(
+            args.report_format, args.project_name, args.version_name))
+        location = response.headers['Location']
+        download_report(location, args.file_name_base)
 
 
-		# Showing how you can interact with the downloaded zip and where to find the
-		# output content. Uncomment the lines below to see how it works.
+        # Showing how you can interact with the downloaded zip and where to find the
+        # output content. Uncomment the lines below to see how it works.
 
-		# with zipfile.ZipFile(zip_file_name_base, 'r') as zipf:
-		# 	with zipf.open("{}/{}/version-license.txt".format(args.project_name, args.version_name), "r") as license_file:
-		# 		print(license_file.read())
-	else:
-		logging.error("Failed to create reports for project {} version {}, status code returned {}".format(
-			args.project_name, args.version_name, response.status_code))
+        # with zipfile.ZipFile(zip_file_name_base, 'r') as zipf:
+        #   with zipf.open("{}/{}/version-license.txt".format(args.project_name, args.version_name), "r") as license_file:
+        #       print(license_file.read())
+    else:
+        logging.error("Failed to create reports for project {} version {}, status code returned {}".format(
+            args.project_name, args.version_name, response.status_code))
 else:
-	logging.warning("Did not find project with name {}".format(args.project_name))
+    logging.warning("Did not find project with name {}".format(args.project_name))


### PR DESCRIPTION
Using this example function, it will automatically retry up to 10 times if anything but a 200 response comes.  However, during a test the server took a long time in processing state creating the report.  I realized there is a specific response of 412 with a specific error code that indicates the report is still processing.  This change would not decrement the retries if this message is received.