### PR TITLE
Add HubSession with timeout and retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,22 @@ pip install blackduck
 ```python
 from blackduck import Client
 import json
+import logging
+import os
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s] {%(module)s:%(lineno)d} %(levelname)s - %(message)s'
+)
 
 bd = Client(
-    token=os.environ.get('blackduck_token', 'YOUR TOKEN HERE'),
-    base_url='https://your.blackduck.url' #!important! no trailing slash
-    #, verify=False # if required
+    token=os.environ.get('blackduck_token', "YOUR TOKEN HERE"),
+    base_url="https://your.blackduck.url",
+    # verify=False  # TLS certificate verification
 )
 
 for project in bd.get_projects():
-  print(project.get('name')
-
+    print(project.get('name'))
 ```
 
 ### Examples

--- a/blackduck/Authentication.py
+++ b/blackduck/Authentication.py
@@ -16,30 +16,18 @@ class BearerAuth(requests.auth.AuthBase):
     
     from .Exceptions import http_exception_handler
 
-    def __init__(
-        self,
-        session=None,
-        token=None,
-        base_url=None,
-        verify=True,
-        timeout=15,
-        ):
-
-        if any(arg == False for arg in (token, base_url)):
+    def __init__(self, session=None, token=None):
+        if any(arg is False for arg in (session, token)):
             raise ValueError(
-                'token & base_url are required'
+                'session & token are required'
             )
 
-        self.verify=verify
         self.client_token = token
         self.auth_token = None
         self.csrf_token = None
         self.valid_until = datetime.utcnow()
 
-        self.auth_url = requests.compat.urljoin(base_url, '/api/tokens/authenticate')
-        self.session = session or requests.session()
-        self.timeout = timeout        
-
+        self.session = session
 
     def __call__(self, request):
         if not self.auth_token or self.valid_until < datetime.utcnow():
@@ -53,9 +41,8 @@ class BearerAuth(requests.auth.AuthBase):
 
         return request
 
-
     def authenticate(self):
-        if not self.verify:
+        if not self.session.verify:
             requests.packages.urllib3.disable_warnings()
             # Announce this on every auth attempt, as a little incentive to properly configure certs
             logger.warn("ssl verification disabled, connection insecure. do NOT use verify=False in production!")
@@ -63,12 +50,8 @@ class BearerAuth(requests.auth.AuthBase):
         try:
             response = self.session.request(
                 method='POST',
-                url=self.auth_url,
-                headers = {
-                    "Authorization" : f"token {self.client_token}"
-                },
-                verify=self.verify,
-                timeout=self.timeout
+                url="/api/tokens/authenticate",
+                headers={"Authorization": f"token {self.client_token}"}
             )
 
             if response.status_code / 100 != 2:
@@ -84,12 +67,12 @@ class BearerAuth(requests.auth.AuthBase):
 
         # Do not handle exceptions - just just more details as to possible causes
         # Thus we do not catch a JsonDecodeError here even though it may occur
-        # - no futher details to give.  
-        except requests.exceptions.ConnectTimeout as connect_timeout:
-            logger.critical(f"could not establish a connection within {self.timeout}s, this may be indicative of proxy misconfiguration")
-            raise connect_timeout
-        except requests.exceptions.ReadTimeout as read_timeout:
-            logger.critical(f"slow or unstable connection, consider increasing timeout (currently set to {self.timeout}s)")
-            raise read_timeout
+        # - no further details to give.
+        except requests.exceptions.ConnectTimeout:
+            logger.critical("could not establish a connection; this may be indicative of proxy misconfiguration")
+            raise
+        except requests.exceptions.ReadTimeout:
+            logger.critical("slow or unstable connection, consider increasing timeout")
+            raise
         else:
             logger.info(f"success: auth granted until {self.valid_until} UTC")

--- a/blackduck/Authentication.py
+++ b/blackduck/Authentication.py
@@ -6,13 +6,20 @@ Created on Dec 23, 2020
 '''
  
 import requests
+from requests.auth import AuthBase
 import logging
 import json
 from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
-class BearerAuth(requests.auth.AuthBase):
+
+class NoAuth(AuthBase):
+    def __call__(self, r):
+        return r
+
+
+class BearerAuth(AuthBase):
     
     from .Exceptions import http_exception_handler
 
@@ -51,6 +58,7 @@ class BearerAuth(requests.auth.AuthBase):
             response = self.session.request(
                 method='POST',
                 url="/api/tokens/authenticate",
+                auth=NoAuth(),  # temporarily strip authentication to avoid infinite recursion
                 headers={"Authorization": f"token {self.client_token}"}
             )
 

--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -82,13 +82,24 @@ class Client:
         verify=True,
         timeout=15.0,  # in seconds
         retries=3):
+        """Instantiate a Client for use with Hub's REST-API
 
-        self.base_url=base_url
+        Args:
+            token (str): Access Token obtained from the Hub UI: System -> My Access Tokens
+            base_url (str): e.g. "https://your.blackduck.url"
+            session (requests.Session): custom session if specified.  For advanced users only.
+                If not provided, a HubSession with recommended defaults will be generated and used.
+                Any custom session must incorporate a base_url in every request as a plain
+                requests.Session() will not work.  See HubSession implementation for an example.
+            auth (requests.auth.AuthBase): custom authorization if specified. For advanced users only.
+                If not provided, one based on the access token is generated and used.
+            verify (bool): TLS certificate verification. Defaults to True.
+            timeout (float): request timeout in seconds. Defaults to 15 seconds.
+            retries (int): maximum number of times to retry a request. Defaults to 3.
+        """
+        self.base_url = base_url
         self.session = session or HubSession(base_url, timeout, retries, verify)
-        self.auth = auth or BearerAuth(
-            session = self.session,
-            token=token
-        )
+        self.session.auth = auth or BearerAuth(session=self.session, token=token)
 
     def print_methods(self):
         import inspect

--- a/blackduck/ClientCore.py
+++ b/blackduck/ClientCore.py
@@ -47,7 +47,6 @@ def _request(
             method=method, 
             url=url, 
             headers=headers,
-            auth=self.auth, 
             **kwargs
         )
 

--- a/blackduck/ClientCore.py
+++ b/blackduck/ClientCore.py
@@ -46,8 +46,7 @@ def _request(
         response = self.session.request(
             method=method, 
             url=url, 
-            headers=headers, 
-            verify=self.verify, 
+            headers=headers,
             auth=self.auth, 
             **kwargs
         )
@@ -62,12 +61,12 @@ def _request(
 
     # Do not handle exceptions - just just more details as to possible causes
     # Thus we do not catch a JsonDecodeError here even though it may occur
-    except requests.exceptions.ConnectTimeout as connect_timeout:
-        logger.critical(f"could not establish a connection within {self.timeout}s, this may be indicative of proxy misconfiguration")
-        raise connect_timeout
-    except requests.exceptions.ReadTimeout as read_timeout:
-        logger.critical(f"slow or unstable connection, consider increasing timeout (currently set to {self.timeout}s)")
-        raise read_timeout
+    except requests.exceptions.ConnectTimeout:
+        logger.critical("could not establish a connection; this may be indicative of proxy misconfiguration")
+        raise
+    except requests.exceptions.ReadTimeout:
+        logger.critical("slow or unstable connection, consider increasing timeout")
+        raise
     else:
         return response_json
     
@@ -156,13 +155,13 @@ def _get_base_resource_url(self, resource_name, is_public=True, **kwargs):
     if is_public:
         resources = self._request(
             method="GET",
-            url=self.base_url + f"/api/",
+            url="/api/",
             name='_get_base_resource_url',
             **kwargs
         )
         return resources.get(resource_name, "")
     else:
-        return self.base_url + f"/api/{resource_name}"
+        return f"/api/{resource_name}"
 
 def get_base_resource(self, resource_name, is_public=True, **kwargs):
     return self._request(


### PR DESCRIPTION
Details:
 - enable timeout (as it was being ignored before)
 - expose retries as named argument to Client
 - include base_url in every request
 - updated demo_client.py and README.md