### PR TITLE
Add uniformity and debugging improvements to list_resources and get_resource

### DIFF
--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -118,13 +118,16 @@ class Client:
         """
         if parent is not None and not isinstance(parent, dict):
             raise TypeError("parent parameter must be a dict if not None")
+
         if not parent:
             # the root resources are in a different format (name -> href)
             # compared to (rel, href) pairs in _meta.links
             if self.root_resources_dict is None:
                 # cache root resources for efficiency
-                resp_json = self.session.get("/api/").json()
+                resp = self.session.get("/api/")
+                resp_json = resp.json()
                 del resp_json['_meta']
+                resp_json['href'] = resp.url  # save url to root iteself
                 self.root_resources_dict = resp_json
             return self.root_resources_dict
         else:
@@ -140,6 +143,7 @@ class Client:
                 resources_dict = {}
                 for res in rel_href_pairs:
                     resources_dict[res['rel']] = res['href']
+                resources_dict['href'] = safe_get(parent, '_meta', 'href')  # save url to parent itself
                 parent[key] = resources_dict  # cache for future use
             return parent[key]
 

--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -11,6 +11,7 @@ from .Utils import find_field, safe_get
 from .Authentication import BearerAuth
 import logging
 import os
+from pprint import pprint
 import requests.packages.urllib3
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
@@ -70,7 +71,7 @@ class Client:
     )
 
     from .ClientCore import (
-        _request, _get_items, _get_base_resource_url, _get_base, _get_resource_url, get_resource, list_resources, get_metadata, get_parameter_string
+        _request, _get_items, get_parameter_string
     )
 
     def __init__(
@@ -102,6 +103,94 @@ class Client:
         self.base_url = base_url
         self.session = session or HubSession(base_url, timeout, retries, verify)
         self.session.auth = (auth or BearerAuth)(session=self.session, token=token, username=username, password=password)
+        self.root_resources_dict = None
+
+    def list_resources(self, parent=None):
+        """List resources that can be fetched
+
+        Args:
+            self:
+            parent (dict/json): resource object from prior get_resource invocations.
+                                Defaults to None (for root /api/ base).
+
+        Returns:
+            dict(str -> str): of public resource names to urls
+        """
+        if parent is not None and not isinstance(parent, dict):
+            raise TypeError("parent parameter must be a dict if not None")
+        if not parent:
+            # the root resources are in a different format (name -> href)
+            # compared to (rel, href) pairs in _meta.links
+            if self.root_resources_dict is None:
+                # cache root resources for efficiency
+                resp_json = self.session.get("/api/").json()
+                del resp_json['_meta']
+                self.root_resources_dict = resp_json
+            return self.root_resources_dict
+        else:
+            key = '_hub_rest_api_python_resources_dict'
+            if key not in parent:
+                obj = safe_get(parent, '_meta', 'links')
+                try:
+                    rel_href_pairs = iter(obj)
+                except TypeError:
+                    logger.error("not iterable bd_object:")
+                    pprint(obj)
+                    raise
+                resources_dict = {}
+                for res in rel_href_pairs:
+                    resources_dict[res['rel']] = res['href']
+                parent[key] = resources_dict  # cache for future use
+            return parent[key]
+
+    def get_resource(self, name, parent=None, items=True, **kwargs):
+        """Fetch a resource
+
+        Args:
+            self:
+            name (str): resource name i.e. specific key from list_resources()
+            parent (dict/json): resource object from prior get_resource() call.
+                                Use None for root /api/ base.
+            items (bool, optional): enable resource generator for paginated results. Defaults to True.
+            kwargs: passed to requests.session.get
+
+        Returns:
+            list (items=True) or dict formed from returned json
+        """
+        if not isinstance(name, str) or not name:
+            raise TypeError("name parameter must be a non-empty str")
+        if parent is not None and not isinstance(parent, dict):
+            raise TypeError("parent parameter must be a dict if not None")
+        resources_dict = self.list_resources(parent)
+        if name not in resources_dict:
+            msg = f"resource name '{name}' not found in available resources"
+            logger.error(msg)
+            pprint(resources_dict)
+            raise KeyError(msg)
+        url = resources_dict[name]
+
+        fn = self._get_items if items else self._request
+        return fn(
+            method='GET',
+            url=url,
+            name=name,
+            **kwargs
+        )
+
+    def get_metadata(self, name, parent=None, **kwargs):
+        """Fetch resource metadata and other useful data such as totalCount
+
+        Args:
+            name (str): resource name i.e. specific key from list_resources()
+            parent (dict/json): resource object from prior get_resource() call.
+                                Use None for root /api/ base.
+
+        Returns:
+            dict/json: named resource metadata
+        """
+        # limit: 0 works for 'projects' but not for 'codeLocations' or project 'versions'
+        kwargs['params'] = {'limit': 1}
+        return self.get_resource(name, parent, items=False, **kwargs)
 
     def print_methods(self):
         import inspect

--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -106,7 +106,7 @@ class Client:
         self.root_resources_dict = None
 
     def list_resources(self, parent=None):
-        """List resources that can be fetched
+        """List resources that can be fetched.
 
         Args:
             self:
@@ -115,6 +115,7 @@ class Client:
 
         Returns:
             dict(str -> str): of public resource names to urls
+                              To obtain the url to the parent itself, use key 'href'.
         """
         if parent is not None and not isinstance(parent, dict):
             raise TypeError("parent parameter must be a dict if not None")
@@ -125,10 +126,10 @@ class Client:
             if self.root_resources_dict is None:
                 # cache root resources for efficiency
                 resp = self.session.get("/api/")
-                resp_json = resp.json()
-                del resp_json['_meta']
-                resp_json['href'] = resp.url  # save url to root iteself
-                self.root_resources_dict = resp_json
+                resources_dict = resp.json()
+                resources_dict['href'] = resp.url  # save url to root itself
+                del resources_dict['_meta']
+                self.root_resources_dict = resources_dict
             return self.root_resources_dict
         else:
             key = '_hub_rest_api_python_resources_dict'
@@ -137,7 +138,7 @@ class Client:
                 try:
                     rel_href_pairs = iter(obj)
                 except TypeError:
-                    logger.error("not iterable bd_object:")
+                    logger.error("not iterable obj:")
                     pprint(obj)
                     raise
                 resources_dict = {}

--- a/blackduck/ClientCore.py
+++ b/blackduck/ClientCore.py
@@ -40,7 +40,7 @@ def _request(
     headers.update(kwargs.pop('headers', dict()))
 
     if parameters:
-        url += self._get_parameter_string(parameters)
+        url += self.get_parameter_string(parameters)
 
     try:
         response = self.session.request(
@@ -101,129 +101,6 @@ def _get_items(self, url, method='GET', page_size=100, name='', **kwargs):
             break
 
         offset += page_size     
-
-def _get_base(self, **kwargs):
-    """Utility function to provide base(/api/) object.
-       Base is root of all other calls, hence the common function.
-
-    Returns:
-        dict: api base resource
-    """
-    return self._request(
-            method="GET",
-            url="/api/",
-            name='_get_base_resource_url',
-            **kwargs
-    )
-
-def _get_base_resource_url(self, name, public=True, **kwargs):
-    """Utility function to get url for a given base(/api/) resouce
-
-    Args:
-        name (str)
-
-    Raises:
-        KeyError: on key not found
-
-    Returns:
-        str: url to named resource
-    """
-    res = self._get_base(**kwargs).get(name) if public else f"/api/{name}"
-    
-    if not res:
-        raise KeyError(f"'/api/ has no such key '{name}', available keys = {self.list_resources()}")
-    return res
-
-def _get_resource_url(self, source, name, public=True):
-    """Utility function to get url for a given name
-
-    Args:
-        source (dict/json): resource object i.e. project
-        name (str): name of api sub-resource i.e. versions
-        public (bool): whether the resource is part of the public api
-    Raises:
-        KeyError: on key not found
-
-    Returns:
-        str: url to named resource
-    """
-    res = f"{self.get_url(source)}/{name}" if not public else find_field(
-        data_to_filter=safe_get(source, '_meta', 'links'),
-        field_name='rel',
-        field_value=name
-    )
-
-    if None == res:
-        raise KeyError(f"'{get_resource_name(source)}' object has no such key '{name}', available keys = {self.list_resources(source)}")
-    return safe_get(res, 'href')
-
-def get_resource(self, source=None, name=None, items=True, public=True, **kwargs):
-    """Generic function to facilitate subresource fetching  
-
-    Args:
-        source (dict/json): Source resource object i.e. project
-        name (str): Name of targetted resource i.e. 'versions'
-        items (bool, optional): Enable resource generator. Defaults to True.
-        public (bool, optional): Allow only public api resources. Defaults to True.
-
-    Returns:
-        dict/json: named resource object
-    """
-    if None == name:
-        raise ValueError("'name' cannot be null")
-    if None == source:
-        url = self._get_base_resource_url(name, public)
-    else:
-        url = self._get_resource_url(source, name, public)
-
-    fn = self._get_items if items else self._request
-    return fn(
-        method='GET',
-        url=url,
-        name=name,
-        **kwargs
-    )
-
-def get_metadata(self, source=None, name=None, items=True, public=True, **kwargs):
-    """ Generic function to facilitate subresource metadata fetching  
-
-    Args:
-        source (dict/json): Source resource object i.e. project
-        name (str): Name of targetted resource i.e. 'versions'
-        items (bool, optional): Enable resource generator. Defaults to True.
-        public (bool, optional): Allow only public api resources. Defaults to True.
-
-    Returns:
-        dict/json: named resource metadata
-    """
-    if None == name:
-        raise ValueError("'name' cannot be null")
-    if None == source:
-        url = self._get_base_resource_url(name, public)
-    else:
-        url = self._get_resource_url(source, name, public)
-
-    return self._request(
-        method='GET',
-        url=url,
-        params={'limit':0},
-        name=name,
-        **kwargs
-    )
-
-def list_resources(self, source=None, **kwargs):
-    """Utility function to list available subresources
-
-    Optional Args:
-        source (dict/json): ..of subresources. Defaults to None / API Base.
-
-    Returns:
-        list: available *public* resources
-    """
-    if None==source:
-        base = self._get_base(**kwargs)
-        return [key for key, value in base.items()]
-    return [res.get('rel') for res in safe_get(source, '_meta', 'links')]
 
 def get_parameter_string(self, parameters=list()):
     return '?' + '&'.join(parameters) if parameters else ''

--- a/blackduck/ClientCore.py
+++ b/blackduck/ClientCore.py
@@ -78,11 +78,12 @@ def _get_items(self, url, method='GET', page_size=100, name='', **kwargs):
         page_size (int, optional): [description]. Defaults to 100.
         name (str, optional): [description]. Defaults to ''.
 
-    Yields:
-        [type]: [description]
+    Returns:
+        list(dict/json): list of items
     """
     offset = 0
     params = kwargs.pop('params', dict())
+    all_items = []
     while True:
         params.update({'offset':f"{offset}", 'limit':f"{page_size}"})
         items = self._request(
@@ -93,12 +94,11 @@ def _get_items(self, url, method='GET', page_size=100, name='', **kwargs):
             **kwargs
         ).get('items', list())
 
-        for item in items:
-            yield item
+        all_items.extend(items)
 
         if len(items) < page_size:
             # This will be true if there are no more 'pages' to view
-            break
+            return all_items
 
         offset += page_size     
 

--- a/blackduck/ClientCore.py
+++ b/blackduck/ClientCore.py
@@ -35,7 +35,8 @@ def _request(
     """
 
     headers = {
-        'accept' : 'application/json'
+        'accept': 'application/json',
+        'content-type': 'application/json'
     }
     headers.update(kwargs.pop('headers', dict()))
 
@@ -55,6 +56,9 @@ def _request(
                 response=response,
                 name=name
             )
+
+        if 'Content-Type' in response.headers and 'internal' in response.headers['Content-Type']:
+            logging.warning("Response contains internal proprietary Content-Type: " + response.headers['Content-Type'])
 
         response_json = response.json()
 

--- a/blackduck/ClientCore.py
+++ b/blackduck/ClientCore.py
@@ -82,12 +82,12 @@ def _get_items(self, url, method='GET', page_size=100, name='', **kwargs):
         page_size (int, optional): [description]. Defaults to 100.
         name (str, optional): [description]. Defaults to ''.
 
-    Returns:
-        list(dict/json): list of items
+    Yields:
+        generator(dict/json): of items
     """
     offset = 0
     params = kwargs.pop('params', dict())
-    all_items = []
+
     while True:
         params.update({'offset':f"{offset}", 'limit':f"{page_size}"})
         items = self._request(
@@ -98,11 +98,12 @@ def _get_items(self, url, method='GET', page_size=100, name='', **kwargs):
             **kwargs
         ).get('items', list())
 
-        all_items.extend(items)
+        for item in items:
+            yield item
 
         if len(items) < page_size:
             # This will be true if there are no more 'pages' to view
-            return all_items
+            break
 
         offset += page_size     
 

--- a/blackduck/Exceptions.py
+++ b/blackduck/Exceptions.py
@@ -34,8 +34,8 @@ class UnacceptableContentType(Exception):
 
 def http_exception_handler(self, response, name):
     error_codes = {
-        404 : EndpointNotFound,
-        406 : UnacceptableContentType
+        404: EndpointNotFound,
+        406: UnacceptableContentType
     }
 
     try:
@@ -45,5 +45,5 @@ def http_exception_handler(self, response, name):
 
     error = error_codes.get(response.status_code)
     if error:
-        raise error(f"{name}: {content}")
+        raise error(f"(status code {response.status_code}) {name}: {content}")
     raise NotImplementedError(f"No handler for status code: {response.status_code}")

--- a/test/demo_client.py
+++ b/test/demo_client.py
@@ -11,24 +11,24 @@ from datetime import datetime, timedelta
 import blackduck
 
 def vulns_in_all_project_versions_components(bd):
-    for project in bd.get_resource(name='projects'):
-        for version in bd.get_resource(project, 'versions'):
-            for component in bd.get_resource(version, 'components'):
-                for vulnerability in bd.get_resource(component, 'vulnerabilities'):
+    for project in bd.get_resource('projects'):
+        for version in bd.get_resource('versions', project):
+            for component in bd.get_resource('components', version):
+                for vulnerability in bd.get_resource('vulnerabilities', component):
                     print(f"{project.get('name')}-{version.get('versionName')} [{component.get('componentName')}] has {vulnerability.get('severity')} severity vulnerability '{vulnerability.get('name')}'")
     
 def list_project_subresources(bd):
-    for project in bd.get_resource(name='projects'):
+    for project in bd.get_resource('projects'):
         subresources = bd.list_resources(project)
         print(f"projects has the following subresources: {', '.join(subresources)}")
         return
 
 def list_project_versions(bd):
     i = 1
-    project_count = bd.get_metadata(name='projects').get('totalCount')
-    for project in bd.get_resource(name='projects'):
+    project_count = bd.get_metadata('projects').get('totalCount')
+    for project in bd.get_resource('projects'):
         print(f"Project ({i}/{project_count}): {project.get('name')}")
-        for version in bd.get_resource(project, 'versions'):
+        for version in bd.get_resource('versions', project):
             print(f"  {version.get('versionName')}")
         i += 1
 
@@ -39,7 +39,7 @@ def projects_added_at_4_week_intervals(bd):
     for timestamp in blackduck.Utils.iso8601_timespan(days_ago=365, delta=timedelta(weeks=4)):
         last_count=count
         count=0
-        for project in bd.get_resource(name='projects'):
+        for project in bd.get_resource('projects'):
             created_at = blackduck.Utils.iso8601_to_date(project.get('createdAt'))
             count += (created_at <= blackduck.Utils.iso8601_to_date(timestamp))
 


### PR DESCRIPTION
I spent a couple of days last week trying out Client. These improvements stem from little gotchas encountered during that experience and try to print out meaningful error messages and guide the developer to correct usage of Client.

Good work on consolidating get_base_resource and get_resource as that took me some thinking to de-tangle.