### PR TITLE
Modified way sub projects are determined from activityData to componentType attribute.

### DIFF
--- a/examples/generate_source_reports_for_sub_projects_recursive.py
+++ b/examples/generate_source_reports_for_sub_projects_recursive.py
@@ -92,15 +92,11 @@ def genreportsforversion(projectname,versionname,reportlist):
         projectname, versionname, result.status_code))
 
     for component in components['items']:
-        subname = (component['componentName'] + '_' + component['componentVersionName'] + '.zip')
-        subname = (subname.replace(" ", ""))
-        # Above step is to generate the output from the get_version_components and specifically look at the activityData
-        # portion to indicate whether a component is a KB component, or a subproject.
-        if len(component['activityData']) == 0:
-            # Above checks length of output from activityData is >0. If equals 0, is sub-project.
-            print("activityData is empty, {} is subproject version {}".format(component['componentName'],component['componentVersionName']))
+        # NOTE THIS REQUIRES pip blackduck 0.0.56 to have the correct request header to obtain the componentType attribute.
+        if component['componentType'] == 'SUB_PROJECT':
+            print("is subproject, {} version {}".format(component['componentName'],component['componentVersionName']))
             genreportsforversion(component['componentName'],component['componentVersionName'],reportlist=['FILES'])
-        elif len(component['activityData']) != 0:
+        else:
             print('is OSS component, no report to download')
 
 


### PR DESCRIPTION
NOTE this requires pip blackduck 0.0.56 to ensure the correct request header to obtain componentType e.g. pip install blackduck==0.0.56

It seems the activityData could in some scenarios contain data for sub projects and this broke the previous way this script determined which components were sub projects.  There is a componentType attribute that solves the issue as long as a specific request header is sent - this is a public API.  See <hub-url>/api-doc/public.html#_listing_bom_components .  Switched to using this but it does require the latest blackduck PyPi module.