### PR TITLE
Utility/example for deleting empty project versions older than <d> days

### DIFF
--- a/blackduck/Exceptions.py
+++ b/blackduck/Exceptions.py
@@ -6,7 +6,7 @@ Created on Dec 22, 2020
 '''
 import logging
 from json import JSONDecodeError
-from .Utils import pfmt
+from pprint import pformat
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ def http_exception_handler(self, response, name):
     }
 
     try:
-        content = pfmt(response.json())
+        content = pformat(response.json())
     except JSONDecodeError:
         content = response.text
 

--- a/blackduck/Utils.py
+++ b/blackduck/Utils.py
@@ -34,6 +34,7 @@ def to_datetime(date):
             month=date.month,
             day=date.day
         )
+    raise TypeError(f"object of type {type(date)} cannot be converted to datetime")
         
 
 def timespan(days_ago, from_date=datetime.now(), delta=timedelta(weeks=1)):

--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 2)
+VERSION = (1, 0, 3)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/examples/client/delete_empty_project_versions.py
+++ b/examples/client/delete_empty_project_versions.py
@@ -1,0 +1,51 @@
+from blackduck import Client
+from blackduck.Utils import to_datetime
+
+from datetime import datetime, timedelta
+import argparse
+import logging
+import requests
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="[%(asctime)s] {%(module)s:%(lineno)d} %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser("Delete empty projects and versions, older than <d> days (default 30)")
+parser.add_argument("--base-url", required=True, help="blackduck hub server url e.g. https://your.app.blackduck.com")
+parser.add_argument("--token-file", dest='token_file', help="path to file containing blackduck hub token")
+parser.add_argument("--no-verify", dest='verify', action='store_false', help="disable TLS certificate verification")
+parser.add_argument("--days", dest='days', default=30, type=int, help="projects/versions older than <days> (as int)")
+args = parser.parse_args()
+
+with open(args.token_file, 'r') as tf:
+    access_token = tf.readline().strip()
+
+bd = Client(
+    base_url=args.base_url,
+    token=access_token,
+    verify=args.verify
+)
+
+max_age = datetime.now() - timedelta(days=args.days)
+
+for project in bd.get_resource('projects'):
+    # skip projects younger than max age
+    if to_datetime(project.get('createdAt')) > max_age: continue
+
+    for version in bd.get_resource('versions', project):
+        # skip versions with > 0 code locations
+        if int(bd.get_metadata('codelocations', version).get('totalCount')): continue
+        # skip versions younger than max age
+        if to_datetime(version.get('createdAt')) > max_age: continue
+        # delete all others
+        logger.info(f"deleting {project.get('name')} version {version.get('versionName')}")
+        bd.session.delete(version.get('href')).raise_for_status()
+    
+    # skip projects with any remaining versions
+    if int(bd.get_metadata('versions', project).get('totalCount')): continue
+    # delete all others
+    logger.info(f"deleting {project.get('name')}")
+    bd.session.delete(project.get('href')).raise_for_status()
+ 

--- a/examples/client/delete_empty_project_versions.py
+++ b/examples/client/delete_empty_project_versions.py
@@ -12,7 +12,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-parser = argparse.ArgumentParser("Delete empty projects and versions, older than <d> days (default: 30)")
+parser = argparse.ArgumentParser("delete_empty_project_versions")
 parser.add_argument("--base-url", required=True, help="blackduck hub server url e.g. https://your.app.blackduck.com")
 parser.add_argument("--token-file", dest='token_file', required=True, help="path to file containing blackduck hub token")
 parser.add_argument("--no-verify", dest='verify', action='store_false', help="disable TLS certificate verification")

--- a/examples/client/delete_empty_project_versions.py
+++ b/examples/client/delete_empty_project_versions.py
@@ -7,16 +7,17 @@ import logging
 import requests
 
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     format="[%(asctime)s] {%(module)s:%(lineno)d} %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
-parser = argparse.ArgumentParser("Delete empty projects and versions, older than <d> days (default 30)")
+parser = argparse.ArgumentParser("Delete empty projects and versions, older than <d> days (default: 30)")
 parser.add_argument("--base-url", required=True, help="blackduck hub server url e.g. https://your.app.blackduck.com")
-parser.add_argument("--token-file", dest='token_file', help="path to file containing blackduck hub token")
+parser.add_argument("--token-file", dest='token_file', required=True, help="path to file containing blackduck hub token")
 parser.add_argument("--no-verify", dest='verify', action='store_false', help="disable TLS certificate verification")
-parser.add_argument("--days", dest='days', default=30, type=int, help="projects/versions older than <days> (as int)")
+parser.add_argument("--days", dest='days', default=30, type=int, help="projects/versions older than <days>")
+parser.add_argument("--delete", dest='delete', action='store_true', help="without this flag script will log/print only")
 args = parser.parse_args()
 
 with open(args.token_file, 'r') as tf:
@@ -40,12 +41,12 @@ for project in bd.get_resource('projects'):
         # skip versions younger than max age
         if to_datetime(version.get('createdAt')) > max_age: continue
         # delete all others
-        logger.info(f"deleting {project.get('name')} version {version.get('versionName')}")
-        bd.session.delete(version.get('href')).raise_for_status()
+        logger.info(f"delete {project.get('name')} version {version.get('versionName')}")
+        if args.delete: bd.session.delete(version.get('href')).raise_for_status()
     
     # skip projects with any remaining versions
     if int(bd.get_metadata('versions', project).get('totalCount')): continue
     # delete all others
     logger.info(f"deleting {project.get('name')}")
-    bd.session.delete(project.get('href')).raise_for_status()
+    if args.delete: bd.session.delete(project.get('href')).raise_for_status()
  


### PR DESCRIPTION
- Added new example for deleting empty project versions older than a given number of days
- Made datetime conversion utilities more robust
- Swapped own-implementations for builtin functions where appropriate

Was needing to write something like this anyway, though #173 gave me a little extra motivation :) 

Note: I've not been able to fully test this script - please give it a go and let me know if everything looks right.