### PR TITLE
Increase default page_size to 1000

### DIFF
--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -234,7 +234,7 @@ class Client:
             self.http_error_handler(r)
             raise
 
-    def get_items(self, url, page_size=100, **kwargs):
+    def get_items(self, url, page_size=1000, **kwargs):
         """Fetch 'pages' of items
 
         Args:


### PR DESCRIPTION
Page size of 100 was far too conservative. 1000 will dramatically improve exec times for most users, whilst remaining manageable for resources with many results.

