### PR TITLE
Security issue: Library-created, world-readable config file may contain secrets

### DIFF
--- a/blackduck/Core.py
+++ b/blackduck/Core.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import requests
 import json
 from operator import itemgetter
@@ -17,7 +18,9 @@ def read_config(self):
         raise
         
 def write_config(self):
-    with open(self.configfile,'w') as f:
+    def openfn(cfg, flags):
+        return os.open(cfg, flags, mode=0o600)
+    with open(self.configfile, 'w', opener=openfn) as f:
         json.dump(self.config, f, indent=3)
         
 def get_auth_token(self):

--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -141,7 +141,7 @@ class HubInstance(object):
             self.config['insecure'] = kwargs.get('insecure', False)
             self.config['debug'] = kwargs.get('debug', False)
 
-            if kwargs.get('write_config_flag', True):
+            if kwargs.get('write_config_flag', False):
                 self.write_config()
         except Exception:
             self.read_config()


### PR DESCRIPTION
Currently, the `HubInstance` API writes a world-readable config file that can contain an access token, by default.

These two commits cause the file to be written with mode 600, and disables writing of the file by default.