### PR TITLE
Gsnyder/extended client

### DIFF
--- a/blackduck/Exceptions.py
+++ b/blackduck/Exceptions.py
@@ -32,6 +32,9 @@ class EndpointNotFound(Exception):
 class UnacceptableContentType(Exception):
     pass
 
+class ProjectNotFound(Exception):
+    pass
+    
 def http_exception_handler(self, response, name):
     error_codes = {
         404: EndpointNotFound,

--- a/blackduck/ExtendedClient.py
+++ b/blackduck/ExtendedClient.py
@@ -1,0 +1,58 @@
+import logging
+from .Client import Client
+from .Exceptions import ProjectNotFound
+
+logger = logging.getLogger(__name__)
+
+class Client(Client):
+    def get_project_by_name(self, project_name):
+        """GET a project object by its name.
+
+        Args:
+            project_name (str): of project
+
+        Returns:
+            json/dict: requested object or None
+
+        Raises:
+            requests.exceptions.HTTPError: from response.raise_for_status()
+            json.JSONDecodeError: if response.text is not json
+        """
+        params = {
+            'q': [f"name:{project_name}"]
+        }
+        filtered_projects = [p for p in self.get_items("/api/projects", params=params) if p.get('name') == project_name]
+        assert len(filtered_projects) in [0,1], f"We either found the project or we didn't, but we should never find this many ({len(filtered_projects)})"
+
+        project_obj = filtered_projects[0] if filtered_projects else None
+        return project_obj
+
+    def get_project_version_by_name(self, project_name, version_name):
+        """GET a project-version object by its name.
+
+        Args:
+            project_name (str): of project
+            version_name (str): of version
+
+        Returns:
+            json/dict tuple: requested project and version objects or None, None
+
+        Raises:
+            requests.exceptions.HTTPError: from response.raise_for_status()
+            json.JSONDecodeError: if response.text is not json
+        """
+        project_obj = self.get_project_by_name(project_name)
+
+        if not project_obj:
+            logger.warning(f"Did not find project {project_name} on server at {self.base_url}")
+            return None, None
+
+        params = {
+            'q': [f"name:{version_name}"]
+        }
+
+        filtered_versions = [v for v in self.get_resource("versions", project_obj, params=params) if v.get('versionName') == version_name]
+        assert len(filtered_versions) in [0,1], f"We either found the version or we didn't, but we should never find this many ({len(filtered_versions)})"
+
+        version_obj = filtered_versions[0] if filtered_versions else None
+        return project_obj, version_obj

--- a/blackduck/__init__.py
+++ b/blackduck/__init__.py
@@ -1,3 +1,3 @@
 
 from .HubRestApi import HubInstance
-from .Client import Client
+from .ExtendedClient import Client

--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 4)
+VERSION = (1, 1, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/examples/client/get_project.py
+++ b/examples/client/get_project.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+'''
+Copyright (C) 2021 Synopsys, Inc.
+http://www.blackducksoftware.com/
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+ 
+'''
+import argparse
+import json
+import logging
+import sys
+
+from blackduck import Client
+
+parser = argparse.ArgumentParser("Get a project")
+parser.add_argument("--base-url", required=True, help="Hub server URL e.g. https://your.blackduck.url")
+parser.add_argument("--token-file", dest='token_file', required=True, help="containing access token")
+parser.add_argument("--no-verify", dest='verify', action='store_false', help="disable TLS certificate verification")
+parser.add_argument("project_name")
+args = parser.parse_args()
+
+
+logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+logging.getLogger("blackduck").setLevel(logging.WARNING)
+
+with open(args.token_file, 'r') as tf:
+    access_token = tf.readline().strip()
+
+bd = Client(
+    base_url=args.base_url,
+    token=access_token,
+    verify=args.verify
+)
+
+project = bd.get_project_by_name(args.project_name)
+output_s = json.dumps(project) if project else f"Project {args.project_name} was not found on the server at {args.base_url}"
+print(output_s)
+
+

--- a/examples/client/get_project_version.py
+++ b/examples/client/get_project_version.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+'''
+Copyright (C) 2021 Synopsys, Inc.
+http://www.blackducksoftware.com/
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+ 
+'''
+import argparse
+import json
+import logging
+import sys
+
+from blackduck import Client
+
+parser = argparse.ArgumentParser("Get a project version")
+parser.add_argument("--base-url", required=True, help="Hub server URL e.g. https://your.blackduck.url")
+parser.add_argument("--token-file", dest='token_file', required=True, help="containing access token")
+parser.add_argument("--no-verify", dest='verify', action='store_false', help="disable TLS certificate verification")
+parser.add_argument("project_name")
+parser.add_argument("version_name")
+args = parser.parse_args()
+
+
+logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+logging.getLogger("blackduck").setLevel(logging.WARNING)
+
+with open(args.token_file, 'r') as tf:
+    access_token = tf.readline().strip()
+
+bd = Client(
+    base_url=args.base_url,
+    token=access_token,
+    verify=args.verify
+)
+
+project, version = bd.get_project_version_by_name(args.project_name, args.version_name)
+output_s = json.dumps(version) if version else f"Version {args.version_name} was not found on the server at {args.base_url}"
+print(output_s)
+
+


### PR DESCRIPTION
A proposal to extend the Client interface and add methods for common operations like getting a project by its name or getting a project-version using the project and version names. If this proposal is accepted we can proceed to populate other convenience methods that will reduce the amount of boilerplate code people have to use to retrieve and work with the BD REST objects.