### PR TITLE
fixing issue where object has no attribute error occurs on _check_version_compatibility

### DIFF
--- a/blackduck/Core.py
+++ b/blackduck/Core.py
@@ -183,3 +183,9 @@ def get_matched_components(self, version_obj, limit=9999):
     url = "{}{}".format(url, param_string)
     response = self.execute_get(url)
     return response.json()
+
+def _check_version_compatibility(self):
+    if int(self.bd_major_version) < 2018:
+        raise UnsupportedBDVersion("The BD major version {} is less than the minimum required major version {}".format(self.bd_major_version, 2018))        
+
+    

--- a/blackduck/HubRestApi.py
+++ b/blackduck/HubRestApi.py
@@ -67,7 +67,8 @@ class HubInstance(object):
     from .Core import (
         _create,_get_hub_rest_api_version_info,_get_major_version,_get_parameter_string,_validated_json_data,
         execute_delete,execute_get,execute_post,execute_put,get_api_version,get_apibase,get_auth_token,get_headers,
-        get_limit_paramstring,get_link,get_matched_components,get_tags_url,get_urlbase,read_config,write_config
+        get_limit_paramstring,get_link,get_matched_components,get_tags_url,get_urlbase,read_config,write_config,
+        _check_version_compatibility
     )
     from .Roles import (
         _get_role_url, assign_role_given_role_url, assign_role_to_user_or_group, 
@@ -123,7 +124,7 @@ class HubInstance(object):
         supported_cf_object_types
     )
     from .Licences import ( _get_license_info, get_license_info_for_bom_component, get_licenses )
-    from .Snippet import ( _check_version_compatibility, get_file_matches_for_bom_component )
+    from .Snippet import ( get_file_matches_for_bom_component )
     from .System import ( get_health_checks, get_notifications )
     from .Ldap import ( disable_ldap, enable_ldap, get_ldap_configs, get_ldap_state )
 

--- a/blackduck/Snippet.py
+++ b/blackduck/Snippet.py
@@ -7,10 +7,6 @@ from .Exceptions import UnsupportedBDVersion
 
 logger = logging.getLogger(__name__)
 
-def _check_version_compatibility(self):
-    if int(self.bd_major_version) < 2018:
-        raise UnsupportedBDVersion("The BD major version {} is less than the minimum required major version {}".format(self.bd_major_version, 2018))        
-
 def get_file_matches_for_bom_component(self, bom_component, limit=1000):
     self._check_version_compatibility()
     url = self.get_link(bom_component, "matched-files")

--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 4)
+VERSION = (1, 0, 5)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
Moving _check_version_compatibility to Core to resolve the issue that occurs when attempting to retrieve BOM licenses.