### PR TITLE
Filter out inactive copyrights.

### DIFF
--- a/examples/bd-upstream-copyrights/get_upstream_copyrights.py
+++ b/examples/bd-upstream-copyrights/get_upstream_copyrights.py
@@ -84,12 +84,14 @@ def main():
 
     for component in bd.get_resource("components", project_version):
         try:
-            copyrights = find_copyrights_in_bom_component_origins(component)           \
+            all_copyrights = find_copyrights_in_bom_component_origins(component)       \
                       or find_copyrights_in_github_origins(component)                  \
                       or find_copyrights_in_previous_component_versions(component)
 
-            if copyrights:
-                print_copyrights(component, copyrights)
+            active_copyrights = [c for c in all_copyrights if c['active'] == True]
+
+            if active_copyrights:
+                print_copyrights(component, active_copyrights)
             else:
                 components_with_no_copyrights.append(component)
 


### PR DESCRIPTION
Most inactive copyrights appear to be strings (usually source code)
that loosely _resemble_ a copyright statement, but usually aren't.

I'm not sure why the KB has these "inactive" copyrights at all. My
guess is that they *used* to match the copyright patterns, but those
patterns have changed over time and it no longer matches. So instead
of throwing it away, we just mark it as "inactive".