### PR TITLE
Fix "Session" is not a known member of module

### DIFF
--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -11,7 +11,7 @@ from .Utils import safe_get
 from .Authentication import BearerAuth
 import json
 import logging
-import os
+import requests
 from pprint import pformat
 import requests.packages.urllib3
 from requests.packages.urllib3.util.retry import Retry


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6594915/173336959-01ac8682-6707-4e4a-bf42-b714874bd829.png)

The `requests` module is not imported in `Client.py` resulting in tools like Pylance/Pyright can't find `Session` correctly.
Note that `os` module is not used in `Client.py` so I replace it with `requests`.
