### PR TITLE
Improve generate_html_notices_from_json.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+#restconfig
+.restconfig.json

--- a/examples/generate_html_notices_report_from_json/generate_html_notices_from_json.py
+++ b/examples/generate_html_notices_report_from_json/generate_html_notices_from_json.py
@@ -1,4 +1,5 @@
 from jinja2 import Environment, FileSystemLoader
+from slugify import slugify
 import os
 import json
 import argparse
@@ -13,6 +14,7 @@ date = datetime.date.today()
 
 templates_dir = os.path.dirname(os.path.abspath(__file__))
 env = Environment(loader=FileSystemLoader(templates_dir))
+env.filters['slugify'] = slugify
 template = env.get_template('notices-template.html')
 
 with open(args.output_file_html, 'w+') as fh:

--- a/examples/generate_html_notices_report_from_json/generate_html_notices_from_json.py
+++ b/examples/generate_html_notices_report_from_json/generate_html_notices_from_json.py
@@ -2,12 +2,14 @@ from jinja2 import Environment, FileSystemLoader
 import os
 import json
 import argparse
+import datetime
 
 parser = argparse.ArgumentParser("A program to transform a JSON formatted representation of a Black Duck notices file into a standalone HTML document")
 parser.add_argument("json_file", help="The input JSON file to be converted")
 parser.add_argument("output_file_html", help="The file to output the results to")
 
 args = parser.parse_args()
+date = datetime.date.today()
 
 templates_dir = os.path.dirname(os.path.abspath(__file__))
 env = Environment(loader=FileSystemLoader(templates_dir))
@@ -21,4 +23,6 @@ with open(args.output_file_html, 'w+') as fh:
         fh.write(template.render(componentLicenses=fileContent['componentLicenses'],
                                  licenseTexts=fileContent['licenseTexts'],
                                  componentCopyrightTexts=fileContent['componentCopyrightTexts'],
-                                 projectVersion=fileContent['projectVersion']))
+                                 projectVersion=fileContent['projectVersion'],
+                                 date=date
+                                 ))

--- a/examples/generate_html_notices_report_from_json/head.html
+++ b/examples/generate_html_notices_report_from_json/head.html
@@ -1,0 +1,3 @@
+<head>
+    <title>{{ projectVersion.projectName }} &mdash; {{ projectVersion.versionName }} &mdash; Notices File
+    </title></head>

--- a/examples/generate_html_notices_report_from_json/intro.html
+++ b/examples/generate_html_notices_report_from_json/intro.html
@@ -1,0 +1,14 @@
+<h1>
+    {{ projectVersion.projectName }} <span>&mdash;</span> {{ projectVersion.versionName }} <span>&mdash;</span> Notices File
+</h1>
+<div style="clear:both;display:block;">
+    <div style="display:inline-block;">
+        <span>Phase:</span>
+        <span>{{ projectVersion.versionPhase }}</span>
+    </div>
+    |
+    <div style="display:inline-block;">
+        <span>Distribution:</span>
+        <span>{{ projectVersion.versionDistribution }}</span>
+    </div>
+</div>

--- a/examples/generate_html_notices_report_from_json/notices-template.html
+++ b/examples/generate_html_notices_report_from_json/notices-template.html
@@ -1,20 +1,7 @@
 <!DOCTYPE html>
 <html style="font-family:Open Sans,sans-serif;">
 <body>
-<h1>
-    {{ projectVersion.projectName }} <span>&mdash;</span> {{ projectVersion.versionName }} <span>&mdash;</span> Notices File
-</h1>
-<div style="clear:both;display:block;">
-    <div style="display:inline-block;">
-        <span>Phase:</span>
-        <span>{{ projectVersion.versionPhase }}</span>
-    </div>
-    |
-    <div style="display:inline-block;">
-        <span>Distribution:</span>
-        <span>{{ projectVersion.versionDistribution }}</span>
-    </div>
-</div>
+{% include 'intro.html' %}
 
 <h1 id="comp-header" style="cursor:pointer;">Components</h1>
 <table style="width:100%;border-collapse:collapse;font-family:Open Sans,sans-serif;" id="comp-container">

--- a/examples/generate_html_notices_report_from_json/notices-template.html
+++ b/examples/generate_html_notices_report_from_json/notices-template.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html style="font-family:Open Sans,sans-serif;">
+{% include 'head.html' %}
 <body>
 {% include 'intro.html' %}
 

--- a/examples/generate_html_notices_report_from_json/notices-template.html
+++ b/examples/generate_html_notices_report_from_json/notices-template.html
@@ -83,41 +83,23 @@
 
 
 <script>
-    compheader = document.getElementById("comp-header")
-    if (!(compheader === null)) {
-        compheader.addEventListener("click", function() {
-            container = document.getElementById("comp-container")
+    function makeCollapseable(item){
+        header = document.getElementById(item + "-header")
+        if (!(header === null)) {
+            header.addEventListener("click", function() {
+            container = document.getElementById(item + "-container")
             if (container.style.display === "none") {
                 container.style.display = null;
             } else {
                 container.style.display = "none";
             }
         });
+    }
     }
 
-    copyheader = document.getElementById("copyright-header")
-    if (!(copyheader === null)) {
-        copyheader.addEventListener("click", function() {
-            container = document.getElementById("copyright-container")
-            if (container.style.display === "none") {
-                container.style.display = null;
-            } else {
-                container.style.display = "none";
-            }
-        });
-    }
-
-    licenseheader = document.getElementById("license-header")
-    if (!(licenseheader === null)) {
-        licenseheader.addEventListener("click", function() {
-            container = document.getElementById("license-container")
-            if (container.style.display === "none") {
-                container.style.display = null;
-            } else {
-                container.style.display = "none";
-            }
-        });
-    }
+    makeCollapseable("comp");
+    makeCollapseable("copyright");
+    makeCollapseable("license");
 
 </script>
 

--- a/examples/generate_html_notices_report_from_json/notices-template.html
+++ b/examples/generate_html_notices_report_from_json/notices-template.html
@@ -20,8 +20,8 @@
 <table style="width:100%;border-collapse:collapse;font-family:Open Sans,sans-serif;" id="comp-container">
     <thead>
     <tr style="border-bottom:1px solid black">
-        <th style="text-align:left;background-color:#f6f6f6;font-weight:500">Component</th>
-        <th style="text-align:left;background-color:#f6f6f6;font-weight:500">License</th>
+        <th style="text-align:left;background-color:#f6f6f6;font-weight:500">Component (click for copyrights)</th>
+        <th style="text-align:left;background-color:#f6f6f6;font-weight:500">License (click for license)</th>
     </tr>
     </thead>
     <tbody>
@@ -29,18 +29,29 @@
         <tr style="border-bottom:1px solid black">
             <td>
                 <span>
-                    <span style="font-weight:700">{{ row.component.projectName }}</span>
+                {%  set componentCopyrightFound = (componentCopyrightTexts|length > 0 and 
+                    componentCopyrightTexts | selectattr("componentVersionSummary.projectName", "equalto", row.component.projectName) | selectattr("componentVersionSummary.versionName", "equalto", row.component.versionName) | list | length > 0 ) %}
+                {%  if componentCopyrightFound %}
+                    <a href="#{{ "%s-%s-%s"|format("copyright",row.component.projectName,row.component.versionName) | slugify }}">
+                {% endif %}
+                        <span style="font-weight:700">
+                            {{ row.component.projectName }}</span>
                     <span style="font-weight:500">
                         {% if row.component.versionName %}
                             {{ row.component.versionName }}
                         {% endif %}
                     </span>
+                {%  if componentCopyrightFound %}
+                    </a>
+                {% endif %}
                 </span>
             </td>
             <td>
                 <div>
                     {% if row.licenses|length > 0 %}
+                    <a href="#{{ "%s-%s"|format(row.component.projectName,row.component.versionName) | slugify }}">
                         {{ row.licenses[0]['name'] }}
+                    </a>
                     {% endif %}
                 </div>
             </td>
@@ -53,7 +64,7 @@
     <h1 id="copyright-header" style="cursor:pointer;">Copyright Data</h1>
     <div id="copyright-container">
         {% for row in componentCopyrightTexts %}
-            <h2>
+            <h2 id="{{ "%s-%s-%s"|format("copyright",row.componentVersionSummary.projectName,row.componentVersionSummary.versionName) | slugify}}">
                 {{ row.componentVersionSummary.projectName }} <span>&mdash;</span> {{ row.originFullName }}
             </h2>
             {% for cr in row.copyrightTexts %}
@@ -72,9 +83,12 @@
     {% for row in licenseTexts %}
         <h2>{{ row.name }}</h2>
         <div>
+            <ul>
             {% for comp in row.components %}
-                {{ comp.projectName }} {{ comp.versionName }}{% if not loop.last %},{% endif %}
+                <li id="{{ "%s-%s"|format(comp.projectName,comp.versionName) | slugify }}" style="list-style-type:disc;">
+                    {{ comp.projectName }} {{ comp.versionName }}</li>
             {% endfor %}
+            </ul>
         </div>
         <pre style="background-color:#f6f6f6;border:1px solid black">{{ row.text|e }}</pre>
     {% endfor %}

--- a/examples/generate_html_notices_report_from_json/requirements.txt
+++ b/examples/generate_html_notices_report_from_json/requirements.txt
@@ -1,2 +1,3 @@
 # for use of the template to generate the html
 jinja2
+python-slugify


### PR DESCRIPTION
Adds some quality of life features to the generate_html_notices_from_json report:

- All sections can be collapsed
- Cross links to licenses/copyrights if they exist

Adds `.restconfig.json` to `.gitignore` to prevent unintended commits.