### PR TITLE
fix deprecation warning from urllib3.util.retry

### DIFF
--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -42,7 +42,7 @@ class HubSession(requests.Session):
             total=int(retries),
             backoff_factor=2,  # exponential retry 1, 2, 4, 8, 16 sec ...
             status_forcelist=[429, 500, 502, 503, 504],
-            method_whitelist=['GET']
+            allowed_methods=['GET']
         )
 
         adapter = HTTPAdapter(max_retries=retry_strategy)


### PR DESCRIPTION
According to [urllib3 documentation](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry),

`method_whitelist` will be removed in v2.0 for `urllib3.util.retry.Retry` object.

`allowed_methods` must be used instead.
