### PR TITLE
Remove Client.HubSession retry method whitelist as per #235

### DIFF
--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -42,7 +42,6 @@ class HubSession(requests.Session):
             total=int(retries),
             backoff_factor=2,  # exponential retry 1, 2, 4, 8, 16 sec ...
             status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=['GET']
         )
 
         adapter = HTTPAdapter(max_retries=retry_strategy)


### PR DESCRIPTION
As per #235, currently we only allow retries for `GET` requests, I can't see any reason why we would have limited it so.

By removing the field, the defaults will be used - https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.DEFAULT_ALLOWED_METHODS

Users can still provide their own `session` object to the client constructor if this change is not suitable for them.