### PR TITLE
bump release to match pypi (dependency updates)

### DIFF
--- a/blackduck/__version__.py
+++ b/blackduck/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 1, 0)
+VERSION = (1, 1, 3)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
Bump version to match pypi.

Release includes: #244 through #265

