### PR TITLE
include_license_info in notice report

### DIFF
--- a/blackduck/Reporting.py
+++ b/blackduck/Reporting.py
@@ -25,7 +25,7 @@ def create_version_reports(self, version, report_list, format="CSV"):
     return self.execute_post(version_reports_url, post_data)
 
 valid_notices_formats = ["TEXT", "JSON"]
-def create_version_notices_report(self, version, format="TEXT", include_copyright_info=True):
+def create_version_notices_report(self, version, format="TEXT", include_copyright_info=True, include_license_info=True):
     assert format in valid_notices_formats, "Format must be one of {}".format(valid_notices_formats)
 
     post_data = {
@@ -35,6 +35,8 @@ def create_version_notices_report(self, version, format="TEXT", include_copyrigh
     }
     if include_copyright_info:
         post_data.update({'categories': ["COPYRIGHT_TEXT"] })
+        if include_license_info:
+            post_data.update({'categories': ["COPYRIGHT_TEXT","LICENSE_DATA","LICENSE_TEXT"] })
 
     notices_report_url = self.get_link(version, 'licenseReports')
     return self.execute_post(notices_report_url, post_data)


### PR DESCRIPTION
Hi In Blackduck 2024.7.2 we need this additional params for getting license summary and license text. refer
https://your_blackduck.com/api-doc/public.html#_listing_project_version_license_report_categories